### PR TITLE
[WIP] Typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,9 @@
     "lint": "npm run build && eslint src test"
   },
   "dependencies": {
+    "@types/bluebird": "^3.5.22",
+    "@types/content-type": "^1.1.2",
+    "@types/fs-extra": "^5.0.4",
     "apify-client": "^0.2.9",
     "apify-shared": "^0.0.34",
     "bluebird": "^3.5.0",
@@ -58,6 +61,7 @@
     "ws": "^5.1.0"
   },
   "devDependencies": {
+    "@types/node": "^10.5.2",
     "apify-jsdoc-template": "github:apifytech/apify-jsdoc-template",
     "babel-cli": "^6.26.0",
     "babel-polyfill": "^6.26.0",

--- a/package.json
+++ b/package.json
@@ -44,9 +44,6 @@
     "lint": "npm run build && eslint src test"
   },
   "dependencies": {
-    "@types/bluebird": "^3.5.22",
-    "@types/content-type": "^1.1.2",
-    "@types/fs-extra": "^5.0.4",
     "apify-client": "^0.2.9",
     "apify-shared": "0.0.42",
     "bluebird": "^3.5.0",
@@ -62,6 +59,9 @@
   },
   "devDependencies": {
     "@types/node": "^10.5.2",
+    "@types/bluebird": "^3.5.22",
+    "@types/content-type": "^1.1.2",
+    "@types/fs-extra": "^5.0.4",
     "apify-jsdoc-template": "github:apifytech/apify-jsdoc-template",
     "babel-cli": "^6.26.0",
     "babel-polyfill": "^6.26.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "build": "rm -rf ./build && babel src --out-dir build",
     "build-doc": "npm run clean && npm run build && node ./node_modules/jsdoc/jsdoc.js --package ./package.json -c ./jsdoc/conf.json -d docs",
     "build-toc": "./node_modules/.bin/markdown-toc README.md -i",
-    "test": "npm run build &&  nyc --reporter=html --reporter=text mocha --timeout 60000 --compilers js:babel-core/register --recursive",
+    "test:original": "npm run build &&  nyc --reporter=html --reporter=text mocha --timeout 60000 --compilers js:babel-core/register --recursive",
+    "test": "tsc || echo done && nyc --reporter=html --reporter=text mocha --timeout 60000 --compilers js:babel-core/register --recursive",
     "prepare": "npm run build-toc && npm run build",
     "prepublishOnly": "(test $RUNNING_FROM_SCRIPT || (echo \"You must use publish.sh instead of 'npm publish' directly!\"; exit 1)) && npm test && npm run lint",
     "clean": "rm -rf build",
@@ -58,10 +59,10 @@
     "ws": "^5.1.0"
   },
   "devDependencies": {
-    "@types/node": "^10.5.2",
     "@types/bluebird": "^3.5.22",
     "@types/content-type": "^1.1.2",
     "@types/fs-extra": "^5.0.4",
+    "@types/node": "^10.5.2",
     "apify-jsdoc-template": "github:apifytech/apify-jsdoc-template",
     "babel-cli": "^6.26.0",
     "babel-polyfill": "^6.26.0",
@@ -88,6 +89,7 @@
     "sinon": "^4.1.2",
     "sinon-stub-promise": "^4.0.0",
     "tmp": "^0.0.33",
+    "typescript": "^2.9.2",
     "why-is-node-running": "^2.0.2"
   },
   "optionalDependencies": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,13 +1,14 @@
-import * as consts from 'apify-shared/consts';
+import {ACTOR_EVENT_NAMES} from 'apify-shared/consts';
+export * from 'apify-shared/consts';
 
-consts.DEFAULT_USER_AGENT = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36'; // eslint-disable-line max-len
+export const DEFAULT_USER_AGENT = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36'; // eslint-disable-line max-len
 
 /**
  * Exit codes for the act process.
  * The error codes must be in range 1-128, to avoid collision with signal exits
  * and to ensure Docker will handle them correctly!
  */
-consts.EXIT_CODES = {
+export const EXIT_CODES = {
     SUCCESS: 0,
     ERROR_USER_FUNCTION_THREW: 91,
     ERROR_UNKNOWN: 92,
@@ -17,6 +18,4 @@ consts.EXIT_CODES = {
  * These events are just internal for Apify package so we don't need them
  * in apify-shared package.
  */
-consts.ACTOR_EVENT_NAMES.PERSIST_STATE = 'persistState';
-
-module.exports = consts;
+ACTOR_EVENT_NAMES.PERSIST_STATE = 'persistState';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-import {ACTOR_EVENT_NAMES} from 'apify-shared/consts';
+import { ACTOR_EVENT_NAMES } from 'apify-shared/consts';
 export * from 'apify-shared/consts';
 
 export const DEFAULT_USER_AGENT = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36'; // eslint-disable-line max-len

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,3 +19,13 @@ export const EXIT_CODES = {
  * in apify-shared package.
  */
 ACTOR_EVENT_NAMES.PERSIST_STATE = 'persistState';
+
+export declare const ENV_VARS: {
+    [key: string]: string
+};
+
+export declare const LOCAL_EMULATION_SUBDIRS: {
+    datasets: string,
+    keyValueStores: string,
+    requestQueues: string
+};

--- a/src/key_value_store.ts
+++ b/src/key_value_store.ts
@@ -9,10 +9,9 @@ import { checkParamOrThrow, parseBody } from 'apify-client/build/utils';
 import { ENV_VARS, LOCAL_EMULATION_SUBDIRS } from './constants';
 import { addCharsetToContentType, apifyClient, ensureDirExists } from './utils';
 
-export const LOCAL_EMULATION_SUBDIR: string = LOCAL_EMULATION_SUBDIRS.keyValueStores;
-const MAX_OPENED_STORES: number = 1000;
+export const LOCAL_EMULATION_SUBDIR = LOCAL_EMULATION_SUBDIRS.keyValueStores;
+const MAX_OPENED_STORES = 1000;
 
-type FileType = { contentType: string, extension: string }
 const LOCAL_FILE_TYPES = [
     { contentType: 'application/octet-stream', extension: 'buffer' },
     { contentType: 'application/json', extension: 'json' },
@@ -30,12 +29,17 @@ const emptyDirPromised = Promise.promisify(fsExtra.emptyDir);
 const { keyValueStores } = apifyClient;
 const storesCache = new LruCache({ maxLength: MAX_OPENED_STORES }); // Open key-value stores are stored here.
 
+interface SetValueOptions {
+    contentType?: string | Buffer
+}
+
 /**
  * Helper function to validate params of *.getValue().
  *
  * @ignore
  */
 const validateGetValueParams = (key: string) => {
+    checkParamOrThrow(key, 'key', 'String');
     if (!key) throw new Error('The "key" parameter cannot be empty');
 };
 
@@ -44,12 +48,12 @@ const validateGetValueParams = (key: string) => {
  *
  * @ignore
  */
-const validateSetValueParams = (key, value, options) => {
+const validateSetValueParams = (key: string, value: any, options?: SetValueOptions): void => {
     checkParamOrThrow(key, 'key', 'String');
     checkParamOrThrow(options, 'options', 'Object');
     checkParamOrThrow(options.contentType, 'options.contentType', 'String | Null | Undefined');
 
-    if (value === null && options.contentType !== null && options.contentType !== undefined) {
+    if (value === null && options.contentType != null) {
         throw new Error('The "options.contentType" parameter must not be used when removing the record.');
     }
 
@@ -71,9 +75,9 @@ const validateSetValueParams = (key, value, options) => {
  *
  * @ignore
  */
-export const maybeStringify = (value, options) => {
+export const maybeStringify = (value: any, options: SetValueOptions): any => {
     // If contentType is missing, value will be stringified to JSON
-    if (options.contentType === null || options.contentType === undefined) {
+    if (options.contentType == null) {
         options.contentType = 'application/json';
 
         try {
@@ -131,7 +135,7 @@ export class KeyValueStore {
      * @param  {String}  key Record key.
      * @return {Promise}
      */
-    getValue(key) {
+    getValue(key: string): Promise<any> {
         validateGetValueParams(key);
 
         return keyValueStores
@@ -145,11 +149,11 @@ export class KeyValueStore {
      *
      * @param  {String} key Record key.
      * @param  {Object|String|Buffer} value Record value. If content type is not provided then the value is stringified to JSON.
-     * @param  {Object} [Options]
-     * @param  {Object} [Options.contentType] Content type of the record.
+     * @param  {Object} [options]
+     * @param  {Object} [options.contentType] Content type of the record.
      * @return {Promise}
      */
-    setValue(key, value, options = {}) {
+    setValue(key: string, value: any, options = {}): Promise<any> {
         validateSetValueParams(key, value, options);
 
         // Make copy of options, don't update what user passed.

--- a/src/key_value_store.ts
+++ b/src/key_value_store.ts
@@ -33,8 +33,7 @@ const storesCache = new LruCache({ maxLength: MAX_OPENED_STORES }); // Open key-
  *
  * @ignore
  */
-const validateGetValueParams = (key) => {
-    checkParamOrThrow(key, 'key', 'String');
+const validateGetValueParams = (key: string) => {
     if (!key) throw new Error('The "key" parameter cannot be empty');
 };
 

--- a/src/key_value_store.ts
+++ b/src/key_value_store.ts
@@ -9,8 +9,10 @@ import { checkParamOrThrow, parseBody } from 'apify-client/build/utils';
 import { ENV_VARS, LOCAL_EMULATION_SUBDIRS } from './constants';
 import { addCharsetToContentType, apifyClient, ensureDirExists } from './utils';
 
-export const LOCAL_EMULATION_SUBDIR = LOCAL_EMULATION_SUBDIRS.keyValueStores;
-const MAX_OPENED_STORES = 1000;
+export const LOCAL_EMULATION_SUBDIR: string = LOCAL_EMULATION_SUBDIRS.keyValueStores;
+const MAX_OPENED_STORES: number = 1000;
+
+type FileType = { contentType: string, extension: string }
 const LOCAL_FILE_TYPES = [
     { contentType: 'application/octet-stream', extension: 'buffer' },
     { contentType: 'application/json', extension: 'json' },
@@ -117,7 +119,7 @@ export const maybeStringify = (value, options) => {
  */
 export class KeyValueStore {
 
-    constructor(public storeId:string) {}
+    constructor(public storeId: string) {}
 
     // TODO: Move here the Apify.getValue()/setValue() documentation, and link it from there.
     // This place should be the main source of information.

--- a/src/key_value_store.ts
+++ b/src/key_value_store.ts
@@ -1,8 +1,8 @@
-import fs from 'fs';
-import fsExtra from 'fs-extra';
-import path from 'path';
-import Promise from 'bluebird';
-import contentTypeParser from 'content-type';
+import * as fs from 'fs';
+import * as fsExtra from 'fs-extra';
+import * as path from 'path';
+import * as Promise from 'bluebird';
+import * as contentTypeParser from 'content-type';
 import LruCache from 'apify-shared/lru_cache';
 import { checkParamOrThrow, parseBody } from 'apify-client/build/utils';
 import { ENV_VARS, LOCAL_EMULATION_SUBDIRS } from './constants';
@@ -111,11 +111,8 @@ export const maybeStringify = (value, options) => {
  * @param {String} storeId - ID of the key-value store.
  */
 export class KeyValueStore {
-    constructor(storeId) {
-        checkParamOrThrow(storeId, 'storeId', 'String');
 
-        this.storeId = storeId;
-    }
+    constructor(public storeId:string) {}
 
     // TODO: Move here the Apify.getValue()/setValue() documentation, and link it from there.
     // This place should be the main source of information.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,8 @@
-import Promise from 'bluebird';
-import contentTypeParser from 'content-type';
-import os from 'os';
-import fs from 'fs';
-import fsExtra from 'fs-extra';
+import * as Promise from 'bluebird';
+import * as contentTypeParser from 'content-type';
+import * as os from 'os';
+import * as fs from 'fs';
+import * as fsExtra from 'fs-extra';
 import ApifyClient from 'apify-client';
 import psTree from 'ps-tree';
 import pidusage from 'pidusage';
@@ -26,6 +26,7 @@ export const newClient = () => {
     const opts = {
         userId: process.env[ENV_VARS.USER_ID] || null,
         token: process.env[ENV_VARS.TOKEN] || null,
+        baseUrl: null
     };
 
     // Only set baseUrl if overridden by env var, so that 'https://api.apify.com' is used by default.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,9 +1,9 @@
-import * as Promise from 'bluebird';
-import * as contentTypeParser from 'content-type';
-import * as os from 'os';
-import * as fs from 'fs';
-import * as fsExtra from 'fs-extra';
-import ApifyClient from 'apify-client';
+import Promise from 'bluebird';
+import contentTypeParser from 'content-type';
+import os from 'os';
+import fs from 'fs';
+import fsExtra from 'fs-extra';
+import ApifyClient, { IApifyClientConstructorOptions } from 'apify-client';
 import psTree from 'ps-tree';
 import pidusage from 'pidusage';
 import _ from 'underscore';
@@ -26,8 +26,7 @@ export const newClient = () => {
     const opts = {
         userId: process.env[ENV_VARS.USER_ID] || null,
         token: process.env[ENV_VARS.TOKEN] || null,
-        baseUrl: null
-    };
+    } as IApifyClientConstructorOptions;
 
     // Only set baseUrl if overridden by env var, so that 'https://api.apify.com' is used by default.
     // This simplifies local development, which should run against production unless user wants otherwise.

--- a/src/vendor.d.ts
+++ b/src/vendor.d.ts
@@ -1,0 +1,41 @@
+declare module "apify-client" {
+
+    interface IApifyClientConstructor {
+        (options?: IApifyClientConstructorOptions): IApifyClient;
+        new(options?: IApifyClientConstructorOptions): IApifyClient;
+    }
+
+    interface IApifyClient {
+        keyValueStores: {
+            getOrCreateStore(options: { storeName: string }): Promise<IKeyValueStore>;
+            getStore(options: { storeId: string }): Promise<IKeyValueStore>;
+            getRecord(options: any): Promise<TKeyValueStoreRecord>;
+            putRecord(options: any): Promise<any>;
+            deleteRecord(options: any): Promise<any>;
+            deleteStore(options: any): Promise<any>;
+        }
+    }
+
+    export interface IApifyClientConstructorOptions {
+        userId?: string;
+        token?: string;
+        promise?: any;
+        expBackOffMillis?: number;
+        expBackOffMaxRepeats?: number;
+        baseUrl?: string;
+    }
+
+    export interface IKeyValueStore {
+        id: string;
+        userId: string;
+        accessedAt: Date;
+        createdAt: Date;
+        modifiedAt: Date;
+    }
+
+    type TKeyValueStoreRecord = any;
+
+    const ApifyClient: IApifyClientConstructor;
+    export default ApifyClient;
+}
+

--- a/test/puppeteer_live_view_server.js
+++ b/test/puppeteer_live_view_server.js
@@ -3,8 +3,8 @@ import { expect, assert } from 'chai';
 import Promise from 'bluebird';
 import puppeteer from 'puppeteer';
 import Apify from '../build/index';
-import PuppeteerLiveViewServer, { PuppeteerLiveViewBrowser } from '../src/puppeteer_live_view_server';
-import { ENV_VARS } from '../src/constants';
+import PuppeteerLiveViewServer, { PuppeteerLiveViewBrowser } from '../build/puppeteer_live_view_server';
+import { ENV_VARS } from '../build/constants';
 
 const PORT = 0;
 const URL = 'thisshouldfailonclientonly';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "outDir": "./build",
+    "allowJs": true,
+    "lib": ["es2017"],
+    "module": "commonjs",
+    "target": "es2017"
+  },
+  "include": [
+    "./src/**/*"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
     "allowJs": true,
     "lib": ["es2017"],
     "module": "commonjs",
-    "target": "es2017"
+    "target": "es2017",
+    "esModuleInterop": true
   },
   "include": [
     "./src/**/*"


### PR DESCRIPTION
So, here I come with a first Typescript PR. It's really just a rough example of what can be done, the syntax and perhaps the related complexities. I also refactored the code to use `async``await` instead of `Promise` chains. Tell me if you think it looks neater or not. I find a `.catch()` would still sometimes be a better choice than the whole `try``catch` block.

### How to use:
   - Either `npm i -g typescript` or use the one in the package. `Webstorm` provides nice integration tools. Don't know about other IDE's. 
   - If you install Typescript globally, running `tsc` in the project folder will show you a nice list of errors. Those errors do not prevent compilation though, so tests still pass.
   - Check the `vendor.d.ts` file to see how an external dependency might be typed, even though it doesn't use Typescript itself.
   - `tsconfig.json` has various configuration options. Similar to Babel.

### The One Important Issue:
   - Typescript doesn't provide runtime typechecking. There are some packages which help with that but nothing official. Therefore, some runtime typechecks will probably have to stay and we cannot get rid of `checkParamOrThrow()` completely.
   - With that said, we can run `tsc` after building a container on the Platform, and even though the users won't be using Typescript in their code, they will get typechecks against all the typed libraries they will be using, such as `apify-js` or `puppeteer`. On local, we can bake this into `apify run` and add typescript as a dev dependency of the project `apify create` generates.

#### Notes:
   - I migrated the test task to Typescript. There were some hiccups, but nothing too serious since we already test against the pre-built files.
   - ESLint doesn't work with Typescript. We would need to migrate to TSLint.
   - The types as you see them are far from perfect. Any comments on where to keep them, how to name them and general code style are very much appreciated.
   - There's a lot of `any` declarations, which are pretty much useless. Also, whenever Typescript cannot infer a type, it uses `any`. All guides suggest working incrementally and add the specific types in iterations. As the migration progresses, the typechecking gets better and better.
   - Nevertheless, it might be necessary to keep using `any` on user provided data, such as `KeyValueStore` values. It really can be pretty much anything.

Essentially, it's just a proof of concept and a playground to decide whether Typescript is something we want to move forward with.

Let me know what you think!