### PR TITLE
Add max data size validation and chunking to dataset.pushData()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ xxxxxxxxxxxxxxxxxxx
 ===================
 - Fixed invalid URL parsing in RequestList.
 - Added support for non-latin language characters (unicode) in URLs.
+- Added validation of payload size and automatic chunking to `dataset.pushData()`
 
 0.5.47 / 2018-07-20
 ===================

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "apify-client": "^0.2.9",
-    "apify-shared": "0.0.42",
+    "apify-shared": "0.0.47",
     "bluebird": "^3.5.0",
     "content-type": "^1.0.3",
     "fs-extra": "^5.0.0",

--- a/src/dataset.js
+++ b/src/dataset.js
@@ -42,7 +42,7 @@ export const checkAndSerialize = (item, limitBytes, index) => {
     try {
         payload = JSON.stringify(item);
     } catch (err) {
-        throw new Error(`Data item${s}is not serializable to JSON.`);
+        throw new Error(`Data item${s}is not serializable to JSON.\nCause: ${err.message}`);
     }
 
     const bytes = Buffer.byteLength(payload);

--- a/src/dataset.js
+++ b/src/dataset.js
@@ -77,16 +77,16 @@ export const chunkBySize = (items, limitBytes) => {
         const bytes = Buffer.byteLength(payload);
 
         if (bytes <= limitBytes && (bytes + 2) > limitBytes) {
-            // handle cases where wrapping with [] would fail, but solo object is fine
+            // Handle cases where wrapping with [] would fail, but solo object is fine.
             chunks.push(payload);
             lastChunkBytes = bytes;
         } else if (lastChunkBytes + bytes <= limitBytes) {
             if (!Array.isArray(_.last(chunks))) chunks.push([]); // ensure array
             _.last(chunks).push(payload);
-            lastChunkBytes += bytes + 1; // add 1 byte for ',' separator
+            lastChunkBytes += bytes + 1; // Add 1 byte for ',' separator.
         } else {
             chunks.push([payload]);
-            lastChunkBytes = bytes + 2; // add 2 bytes for [] wrapper
+            lastChunkBytes = bytes + 2; // Add 2 bytes for [] wrapper.
         }
     }
 

--- a/src/dataset.js
+++ b/src/dataset.js
@@ -64,32 +64,26 @@ export const checkAndSerialize = (item, limitBytes, index) => {
  * @ignore
  */
 export const chunkBySize = (items, limitBytes) => {
-    const toJsonArray = array => `[${array.join(',')}]`;
+    if (!items.length) return [];
 
-    let lastChunkBytes = 2; // add 2 bytes for [] wrapper
-    const chunks = [];
-    // Split payloads into buckets of valid size
+    let lastChunkBytes = 2; // Add 2 bytes for [] wrapper.
+    const chunks = [[]]; // Prepopulate with an empty array.
+
+    // Split payloads into buckets of valid size.
     for (const payload of items) { // eslint-disable-line
         const bytes = Buffer.byteLength(payload);
-        // Ensure last item is always an array
-        if (!Array.isArray(_.last(chunks))) chunks.push([]);
+
         if (lastChunkBytes + bytes < limitBytes) {
-            // If the item fits in the last chunk, push it there.
             _.last(chunks).push(payload);
             lastChunkBytes += bytes + 1; // add 1 byte for ',' separator
         } else {
-            // Otherwise, the last chunk is full. Serialize it and create a new chunk.
-            const chunk = chunks.pop();
-            chunks.push(toJsonArray(chunk));
             chunks.push([payload]);
             lastChunkBytes = bytes + 2; // add 2 bytes for [] wrapper
         }
     }
 
-    // Stringify last chunk
-    const lastChunk = chunks.pop();
-    chunks.push(toJsonArray(lastChunk));
-    return chunks;
+    // Stringify each chunk.
+    return chunks.map(chunk => `[${chunk.join(',')}]`);
 };
 
 /**

--- a/test/dataset.js
+++ b/test/dataset.js
@@ -6,7 +6,8 @@ import path from 'path';
 import sinon from 'sinon';
 import { leftpad, delayPromise } from 'apify-shared/utilities';
 import { ENV_VARS } from '../build/constants';
-import { LOCAL_FILENAME_DIGITS, Dataset, DatasetLocal, LOCAL_EMULATION_SUBDIR, LOCAL_GET_ITEMS_DEFAULT_LIMIT, MAX_PAYLOAD_SIZE_BYTES } from '../build/dataset';
+import { LOCAL_FILENAME_DIGITS, Dataset, DatasetLocal, LOCAL_EMULATION_SUBDIR,
+    LOCAL_GET_ITEMS_DEFAULT_LIMIT, MAX_PAYLOAD_SIZE_BYTES } from '../build/dataset';
 import { apifyClient } from '../build/utils';
 import * as Apify from '../build/index';
 import { LOCAL_EMULATION_DIR, emptyLocalEmulationSubdir, expectNotLocalEmulation, expectDirEmpty, expectDirNonEmpty } from './_helper';

--- a/test/dataset.js
+++ b/test/dataset.js
@@ -748,21 +748,21 @@ describe('dataset', () => {
 
     describe('utils', async () => {
         it('checkAndSerialize() works', () => {
-            // basic
+            // Basic
             const obj = { foo: 'bar' };
             const json = JSON.stringify(obj);
             expect(checkAndSerialize({}, 100)).to.be.eql('{}');
             expect(checkAndSerialize(obj, 100)).to.be.eql(json);
-            // with index
+            // With index
             expect(checkAndSerialize(obj, 100, 1)).to.be.eql(json);
-            // too large
+            // Too large
             expect(() => checkAndSerialize(obj, 5)).to.throw(Error, 'Data item is too large');
             expect(() => checkAndSerialize(obj, 5, 7)).to.throw(Error, 'at index 7');
-            // bad JSON
+            // Bad JSON
             const bad = {};
             bad.bad = bad;
             expect(() => checkAndSerialize(bad, 100)).to.throw(Error, 'not serializable');
-            // bad data
+            // Bad data
             const str = 'hello';
             expect(() => checkAndSerialize(str, 100)).to.throw(Error, 'not serializable');
             expect(() => checkAndSerialize([], 100)).to.throw(Error, 'not serializable');
@@ -777,21 +777,21 @@ describe('dataset', () => {
             const chunk = `[${json}]`;
             const tripleChunk = `[${json},${json},${json}]`;
             const tripleSize = Buffer.byteLength(tripleChunk);
-            // empty array
+            // Empty array
             expect(chunkBySize([], 10)).to.be.eql([]);
-            // fits easily
+            // Fits easily
             expect(chunkBySize([json], size + 10)).to.be.eql([json]);
             expect(chunkBySize(triple, tripleSize + 10)).to.be.eql([tripleChunk]);
-            // parses back to original objects
+            // Parses back to original objects
             expect(originalTriple).to.be.eql(JSON.parse(tripleChunk));
-            // fits exactly
+            // Fits exactly
             expect(chunkBySize([json], size)).to.be.eql([json]);
             expect(chunkBySize(triple, tripleSize)).to.be.eql([tripleChunk]);
-            // chunks large items individually
+            // Chunks large items individually
             expect(chunkBySize(triple, size)).to.be.eql(triple);
             expect(chunkBySize(triple, size + 1)).to.be.eql(triple);
             expect(chunkBySize(triple, size + 2)).to.be.eql([chunk, chunk, chunk]);
-            // chunks smaller items together
+            // Chunks smaller items together
             expect(chunkBySize(triple, (2 * size) + 3)).to.be.eql([`[${json},${json}]`, chunk]);
             expect(chunkBySize([...triple, ...triple], (2 * size) + 3)).to.be.eql([`[${json},${json}]`, `[${json},${json}]`, `[${json},${json}]`]);
         });

--- a/test/dataset.js
+++ b/test/dataset.js
@@ -5,9 +5,9 @@ import fs from 'fs-extra';
 import path from 'path';
 import sinon from 'sinon';
 import { leftpad, delayPromise } from 'apify-shared/utilities';
-import { ENV_VARS } from '../build/constants';
+import { ENV_VARS, MAX_PAYLOAD_SIZE_BYTES } from '../build/constants';
 import { LOCAL_FILENAME_DIGITS, Dataset, DatasetLocal, LOCAL_EMULATION_SUBDIR,
-    LOCAL_GET_ITEMS_DEFAULT_LIMIT, MAX_PAYLOAD_SIZE_BYTES } from '../build/dataset';
+    LOCAL_GET_ITEMS_DEFAULT_LIMIT } from '../build/dataset';
 import { apifyClient } from '../build/utils';
 import * as Apify from '../build/index';
 import { LOCAL_EMULATION_DIR, emptyLocalEmulationSubdir, expectNotLocalEmulation, expectDirEmpty, expectDirNonEmpty } from './_helper';
@@ -344,7 +344,7 @@ describe('dataset', () => {
                 throw new Error('Should fail!');
             } catch (err) {
                 expect(err).to.be.an('error');
-                expect(err.message).to.include('Pushed data too large!');
+                expect(err.message).to.include('Data item is too large');
             }
         });
         it('should throw on too large file in an array', async () => {
@@ -361,7 +361,7 @@ describe('dataset', () => {
                 throw new Error('Should fail!');
             } catch (err) {
                 expect(err).to.be.an('error');
-                expect(err.message).to.include('Pushed data at index 3 too large!');
+                expect(err.message).to.include('Data item at index 3 is too large');
             }
         });
 

--- a/test/dataset.js
+++ b/test/dataset.js
@@ -242,7 +242,7 @@ describe('dataset', () => {
     describe('remote', async () => {
         const mockData = bytes => 'x'.repeat(bytes);
 
-        it('should succesfully save data', async () => {
+        it('should succesfully save simple data', async () => {
             const dataset = new Dataset('some-id');
             const mock = sinon.mock(apifyClient.datasets);
 
@@ -272,7 +272,7 @@ describe('dataset', () => {
             mock.restore();
         });
 
-        it('should successfully chunk large data', async () => {
+        it('should successfully save large data', async () => {
             const half = mockData(MAX_PAYLOAD_SIZE_BYTES / 2);
 
             const dataset = new Dataset('some-id');
@@ -303,7 +303,7 @@ describe('dataset', () => {
             mock.restore();
         });
 
-        it('should successfully chunk small data', async () => {
+        it('should successfully save lots of small data', async () => {
             const count = 20;
             const string = mockData(MAX_PAYLOAD_SIZE_BYTES / count);
             const chunk = { foo: string, bar: 'baz' };
@@ -337,6 +337,7 @@ describe('dataset', () => {
         });
 
         it('should throw on too large file', async () => {
+            const mock = sinon.mock(apifyClient.datasets);
             const full = mockData(MAX_PAYLOAD_SIZE_BYTES);
             const dataset = new Dataset('some-id');
             try {
@@ -346,8 +347,16 @@ describe('dataset', () => {
                 expect(err).to.be.an('error');
                 expect(err.message).to.include('Data item is too large');
             }
+            mock.expects('deleteDataset')
+                .once()
+                .withArgs({ datasetId: 'some-id' })
+                .returns(Promise.resolve());
+            await dataset.delete();
+            mock.verify();
+            mock.restore();
         });
         it('should throw on too large file in an array', async () => {
+            const mock = sinon.mock(apifyClient.datasets);
             const full = mockData(MAX_PAYLOAD_SIZE_BYTES);
             const dataset = new Dataset('some-id');
             try {
@@ -363,6 +372,13 @@ describe('dataset', () => {
                 expect(err).to.be.an('error');
                 expect(err.message).to.include('Data item at index 3 is too large');
             }
+            mock.expects('deleteDataset')
+                .once()
+                .withArgs({ datasetId: 'some-id' })
+                .returns(Promise.resolve());
+            await dataset.delete();
+            mock.verify();
+            mock.restore();
         });
 
 

--- a/test/dataset.js
+++ b/test/dataset.js
@@ -6,7 +6,7 @@ import path from 'path';
 import sinon from 'sinon';
 import { leftpad, delayPromise } from 'apify-shared/utilities';
 import { ENV_VARS } from '../build/constants';
-import { LOCAL_FILENAME_DIGITS, Dataset, DatasetLocal, LOCAL_EMULATION_SUBDIR, LOCAL_GET_ITEMS_DEFAULT_LIMIT } from '../build/dataset';
+import { LOCAL_FILENAME_DIGITS, Dataset, DatasetLocal, LOCAL_EMULATION_SUBDIR, LOCAL_GET_ITEMS_DEFAULT_LIMIT, MAX_PAYLOAD_SIZE_BYTES } from '../build/dataset';
 import { apifyClient } from '../build/utils';
 import * as Apify from '../build/index';
 import { LOCAL_EMULATION_DIR, emptyLocalEmulationSubdir, expectNotLocalEmulation, expectDirEmpty, expectDirNonEmpty } from './_helper';
@@ -245,12 +245,12 @@ describe('dataset', () => {
 
             mock.expects('putItems')
                 .once()
-                .withArgs({ datasetId: 'some-id', data: { foo: 'bar' } })
+                .withArgs({ datasetId: 'some-id', data: JSON.stringify({ foo: 'bar' }) })
                 .returns(Promise.resolve(null));
 
             mock.expects('putItems')
                 .once()
-                .withArgs({ datasetId: 'some-id', data: [{ foo: 'hotel;' }, { foo: 'restaurant' }] })
+                .withArgs({ datasetId: 'some-id', data: JSON.stringify([{ foo: 'hotel;' }, { foo: 'restaurant' }]) })
                 .returns(Promise.resolve(null));
 
             await dataset.pushData({ foo: 'bar' });


### PR DESCRIPTION
Implements https://github.com/apifytech/apify-js/issues/70
Replaces https://github.com/apifytech/apify-shared-js/pull/5

Minor change in `apify-client` is necessary to accept pre-serialized values.