### PR TITLE
Support XML extension in local KeyValueStore

### DIFF
--- a/src/key_value_store.js
+++ b/src/key_value_store.js
@@ -17,6 +17,7 @@ const LOCAL_FILE_TYPES = [
     { contentType: 'text/plain', extension: 'txt' },
     { contentType: 'image/jpeg', extension: 'jpg' },
     { contentType: 'image/png', extension: 'png' },
+    { contentType: 'application/xml', extension: 'xml' },
 ];
 const DEFAULT_LOCAL_FILE_TYPE = LOCAL_FILE_TYPES[0];
 


### PR DESCRIPTION
Add support for XML extension per https://github.com/apifytech/apify-js/issues/130

Also would like to open discussion on more extensions we should add.
Perhaps .html ? .css ? various archives?