### PR TITLE
Add a .stop() function to PuppeteerCrawler and BasicCrawler

### DIFF
--- a/src/autoscaled_pool.js
+++ b/src/autoscaled_pool.js
@@ -221,10 +221,11 @@ export default class AutoscaledPool {
     }
 
     /**
-     * Stops the auto-scaled pool, discarding all currently running tasks.
+     * Stops the auto-scaled pool, discards all currently running tasks and destroys it.
      */
     stop() {
         if (this.resolve) this.resolve();
+        // _destroy gets called 10 lines above so no need to do it here
     }
 
     /**

--- a/src/autoscaled_pool.js
+++ b/src/autoscaled_pool.js
@@ -221,6 +221,13 @@ export default class AutoscaledPool {
     }
 
     /**
+     * Stops the auto-scaled pool, discarding all currently running tasks.
+     */
+    stop() {
+        if (this.resolve) this.resolve();
+    }
+
+    /**
      * Gets called every AUTOSCALE_INTERVAL_MILLIS and saves number of free bytes in this.freeBytesSnapshots.
      *
      * Every:

--- a/src/basic_crawler.js
+++ b/src/basic_crawler.js
@@ -144,14 +144,18 @@ export default class BasicCrawler {
             maxConcurrency,
             minConcurrency,
             minFreeMemoryRatio,
-            runTaskFunction: () => this._runTaskFunction(),
+            runTaskFunction: () => {
+                if (this.isStopped) return null;
+
+                return this._runTaskFunction();
+            },
             isTaskReadyFunction: () => {
-                if (isMaxPagesExceeded()) return Promise.resolve(false);
+                if (isMaxPagesExceeded() || this.isStopped) return Promise.resolve(false);
 
                 return this._isTaskReadyFunction();
             },
             isFinishedFunction: () => {
-                if (isMaxPagesExceeded()) return Promise.resolve(true);
+                if (isMaxPagesExceeded() || this.isStopped) return Promise.resolve(true);
 
                 return isFinishedFunction
                     ? isFinishedFunction()
@@ -167,7 +171,14 @@ export default class BasicCrawler {
      * @return {Promise}
      */
     run() {
+        this.isStopped = false;
         return this.autoscaledPool.run();
+    }
+    /**
+     * Stops the crawler by preventing crawls of additional pages. Pages already running are not terminated.
+     */
+    stop() {
+        this.isStopped = true;
     }
 
     /**

--- a/src/puppeteer_crawler.js
+++ b/src/puppeteer_crawler.js
@@ -207,8 +207,8 @@ export default class PuppeteerCrawler {
      */
     run() {
         if (this.isStopped) this.puppeteerPool = new PuppeteerPool(this.puppeteerPoolOptions);
-        this.stopPromise = new Promise((resolve, reject) => {
-            this.stopPromiseResolve = reject;
+        this.isRunningPromise = new Promise((resolve, reject) => {
+            this.isRunningReject = reject;
         });
         this.isStopped = false;
         return this.basicCrawler.run()
@@ -220,7 +220,7 @@ export default class PuppeteerCrawler {
      */
     stop() {
         this.isStopped = true;
-        this.stopPromiseResolve();
+        this.isRunningReject();
         this.basicCrawler.stop();
         return this.puppeteerPool.destroy();
     }
@@ -260,7 +260,7 @@ export default class PuppeteerCrawler {
                     .timeout(PAGE_CLOSE_TIMEOUT_MILLIS, 'Operation timed out.')
                     .catch(err => log.debug('PuppeteerCrawler: Page.close() failed.', { reason: err ? err.message : err }));
             });
-        return Promise.race([finalPromise, this.stopPromise]);
+        return Promise.race([finalPromise, this.isRunningPromise]);
     }
 
     _gotoFunction(...args) {

--- a/src/puppeteer_pool.js
+++ b/src/puppeteer_pool.js
@@ -110,6 +110,7 @@ export default class PuppeteerPool {
         checkParamOrThrow(launchPuppeteerOptions, 'opts.launchPuppeteerOptions', 'Maybe Object');
 
         // Config.
+        this.isDestroyed = false;
         this.maxOpenPagesPerInstance = maxOpenPagesPerInstance;
         this.retireInstanceAfterRequestCount = retireInstanceAfterRequestCount;
         this.killInstanceAfterMillis = killInstanceAfterMillis;
@@ -290,6 +291,7 @@ export default class PuppeteerPool {
                 return page;
             })
             .catch((err) => {
+                if (this.isDestroyed) return;
                 log.exception(err, 'PuppeteerPool: browser.newPage() failed', { id: instance.id });
                 this._retireInstance(instance);
 
@@ -302,6 +304,7 @@ export default class PuppeteerPool {
      * Closes all the browsers.
      */
     destroy() {
+        this.isDestroyed = true;
         clearInterval(this.instanceKillerInterval);
         process.removeListener('SIGINT', this.sigintListener);
 

--- a/src/puppeteer_pool.js
+++ b/src/puppeteer_pool.js
@@ -110,7 +110,6 @@ export default class PuppeteerPool {
         checkParamOrThrow(launchPuppeteerOptions, 'opts.launchPuppeteerOptions', 'Maybe Object');
 
         // Config.
-        this.isDestroyed = false;
         this.maxOpenPagesPerInstance = maxOpenPagesPerInstance;
         this.retireInstanceAfterRequestCount = retireInstanceAfterRequestCount;
         this.killInstanceAfterMillis = killInstanceAfterMillis;
@@ -291,7 +290,6 @@ export default class PuppeteerPool {
                 return page;
             })
             .catch((err) => {
-                if (this.isDestroyed) return;
                 log.exception(err, 'PuppeteerPool: browser.newPage() failed', { id: instance.id });
                 this._retireInstance(instance);
 
@@ -304,7 +302,6 @@ export default class PuppeteerPool {
      * Closes all the browsers.
      */
     destroy() {
-        this.isDestroyed = true;
         clearInterval(this.instanceKillerInterval);
         process.removeListener('SIGINT', this.sigintListener);
 

--- a/test/puppeteer_crawler.js
+++ b/test/puppeteer_crawler.js
@@ -104,6 +104,7 @@ describe('PuppeteerCrawler', () => {
             expect(request.userData.title).to.be.eql('Example Domain');
         });
 
+        await Apify.utils.sleep(10); // Wait for event loop to unwind.
         await puppeteerCrawler.run();
 
         expect(processed).to.have.lengthOf(30);


### PR DESCRIPTION
This PR enables stopping of running crawlers by calling `crawler.stop()`. The behavior is a little different between BasicCrawler and PuppeteerCrawler, but on the surface they behave the same.

   - Running requests are not terminated, since the handle(Page|Request)Function is user provided, there's no way to abort already running http requests.
   - New requests are prevented from being sent.
   - In progress requests that manage to finish are not marked as finished and will therefore be retried after the stop.
       - this way we may do a little extra work, but we always know where to start next time (for example on container migration)
   - AutoscaledPool and PuppeteerPool are destroyed and new ones are created on crawler restart
   - Error logging of failed requests is suspended after stopping the crawler

Question: How much of this should go into the documentation comments?