### PR TITLE
Max memory env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -789,7 +789,17 @@ The following table shows the basic environment variables used by Apify SDK:
                 By default, the log level is set to <code>INFO</code>, which means that <code>DEBUG</code> messages
                 are not printed to console.
               </td>
-            </tr>
+          </tr>
+          <tr>
+              <td><code>APIFY_MEMORY_MBYTES</code></td>
+              <td>
+                Sets the amount of system memory in megabytes to be used by the running process. This is not a hard limit
+                however, only a threshold for the autoscaling feature. It is used to limit the number of concurrently running
+                tasks. Memory leaks not caused by autoscaling will not be confined to this limit. By default,
+                the max amount of memory to be used is set to one quarter of total system memory, i. e. on a system
+                with 8192 MB of memory, the autoscaling feature will only use up to 2048 MB of memory.
+              </td>
+          </tr>
     </tbody>
 </table>
 

--- a/jsdoc/conf.json
+++ b/jsdoc/conf.json
@@ -22,6 +22,7 @@
     "opts": {
         "template": "./node_modules/apify-jsdoc-template",
         "encoding": "utf8",
-        "destination": ".docs"
+        "destination": ".docs",
+        "recurse": true
     }
 }

--- a/src/autoscaling/snapshotter.js
+++ b/src/autoscaling/snapshotter.js
@@ -1,7 +1,7 @@
 import _ from 'underscore';
 import { betterSetInterval, betterClearInterval } from 'apify-shared/utilities';
 import log from 'apify-shared/log';
-import { ACTOR_EVENT_NAMES } from 'apify-shared/consts';
+import { ACTOR_EVENT_NAMES, ENV_VARS } from 'apify-shared/consts';
 import { checkParamOrThrow } from 'apify-client/build/utils';
 import { getMemoryInfo, isAtHome } from '../utils';
 import events from '../events';
@@ -49,8 +49,6 @@ const DEFAULT_OPTIONS = {
  * @param {Number} [options.snapshotHistorySecs=60]
  *   Sets the interval in seconds for which a history of resource snapshots
  *   will be kept. Increasing this to very high numbers will affect performance.
- * @param {Number} [options.maxMemoryMbytes]
- *   Sets the maximum amount of memory to be used in megabytes.
  * @ignore
  */
 export default class Snapshotter {
@@ -61,7 +59,6 @@ export default class Snapshotter {
             snapshotHistorySecs,
             maxBlockedMillis,
             maxUsedMemoryRatio,
-            maxMemoryMbytes,
         } = _.defaults(options, DEFAULT_OPTIONS);
 
         checkParamOrThrow(eventLoopSnapshotIntervalSecs, 'options.eventLoopSnapshotIntervalSecs', 'Number');
@@ -69,14 +66,13 @@ export default class Snapshotter {
         checkParamOrThrow(snapshotHistorySecs, 'options.snapshotHistorySecs', 'Number');
         checkParamOrThrow(maxBlockedMillis, 'options.maxBlockedMillis', 'Number');
         checkParamOrThrow(maxUsedMemoryRatio, 'options.maxUsedMemoryRatio', 'Number');
-        checkParamOrThrow(maxMemoryMbytes, 'options.maxMemoryMbytes', 'Maybe Number');
 
         this.eventLoopSnapshotIntervalMillis = eventLoopSnapshotIntervalSecs * 1000;
         this.memorySnapshotIntervalMillis = memorySnapshotIntervalSecs * 1000;
         this.snapshotHistoryMillis = snapshotHistorySecs * 1000;
         this.maxBlockedMillis = maxBlockedMillis;
         this.maxUsedMemoryRatio = maxUsedMemoryRatio;
-        this.maxMemoryBytes = maxMemoryMbytes ? maxMemoryMbytes * 1024 * 1024 : null;
+        this.maxMemoryBytes = parseInt(process.env[ENV_VARS.MEMORY_MBYTES], 10) * 1024 * 1024;
 
         this.cpuSnapshots = [];
         this.eventLoopSnapshots = [];
@@ -90,13 +86,13 @@ export default class Snapshotter {
      */
     async start() {
         // Ensure max memory is correctly computed.
-        if (!this.maxMemoryBytes) {
+        if (!this.maxMemoryBytes || Number.isNaN(this.maxMemoryBytes)) {
             const { totalBytes } = await getMemoryInfo();
             if (isAtHome()) {
                 this.maxMemoryBytes = totalBytes;
             } else {
                 this.maxMemoryBytes = Math.ceil(totalBytes / 4);
-                log.info(`Snapshotter: Setting max memory of this run to ${Math.round(this.maxMemoryBytes / 1024 / 1024)} MB.`);
+                log.info(`Snapshotter: Setting max memory of this run to ${Math.round(this.maxMemoryBytes / 1024 / 1024)} MB. Use the ${ENV_VARS.MEMORY_MBYTES} environment variable to override.`); // eslint-disable-line max-len
             }
         }
 

--- a/test/autoscaling/snapshotter.js
+++ b/test/autoscaling/snapshotter.js
@@ -141,9 +141,9 @@ describe('Snapshotter', () => {
     });
 
     it('correctly marks memoryOverloaded', async () => {
+        process.env[ENV_VARS.MEMORY_MBYTES] = 20;
         const options = {
             memorySnapshotIntervalSecs: 0.1,
-            maxMemoryMbytes: 20,
         };
 
         const snapshotter = new Snapshotter(options);
@@ -158,6 +158,7 @@ describe('Snapshotter', () => {
         expect(memorySnapshots[0].isOverloaded).to.be.eql(true);
         expect(memorySnapshots[1].isOverloaded).to.be.eql(true);
         expect(memorySnapshots[2].isOverloaded).to.be.eql(false);
+        delete process.env[ENV_VARS.MEMORY_MBYTES];
     });
 
     it('.get...Sample limits amount of samples', async () => {


### PR DESCRIPTION
Removes the `maxMemoryMbytes` option from `Snapshotter` and replaces it with reading the `APIFY_MEMORY_MBYTES` env var. Updates README.

Also enables generation of docs in subdirectories.