### PR TITLE
Add RequestQueue overload for adding requests

### DIFF
--- a/src/request_queue.js
+++ b/src/request_queue.js
@@ -40,13 +40,12 @@ const queuesCache = new LruCache({ maxLength: MAX_OPENED_QUEUES }); // Open queu
  * @ignore
  */
 const validateAddRequestParams = (request, opts) => {
-    let newRequest;
-    try {
-        checkParamPrototypeOrThrow(request, 'request', Request, 'Apify.Request');
-    } catch (_) {
-        // Delegates request constructor object validation to the Request constructor
-        newRequest = new Request(request);
+    checkParamOrThrow(request, 'request', 'Object');
+
+    if (!(request instanceof Request)) {
+        request = new Request(request);
     }
+
     checkParamOrThrow(opts, 'opts', 'Object');
 
     const { forefront = false } = opts;
@@ -55,7 +54,7 @@ const validateAddRequestParams = (request, opts) => {
 
     if (request.id) throw new Error('Request has already "id" so it cannot be added to the queue!');
 
-    return { forefront, newRequest };
+    return { forefront, request };
 };
 
 /**
@@ -216,7 +215,7 @@ export class RequestQueue {
      * @return {RequestOperationInfo}
      */
     addRequest(request, opts = {}) {
-        const { forefront, newRequest } = validateAddRequestParams(request, opts);
+        const { forefront, request: newRequest } = validateAddRequestParams(request, opts);
 
         if (newRequest) {
             request = newRequest;
@@ -637,7 +636,7 @@ export class RequestQueueLocal {
     }
 
     addRequest(request, opts = {}) {
-        const { forefront, newRequest } = validateAddRequestParams(request, opts);
+        const { forefront, request: newRequest } = validateAddRequestParams(request, opts);
 
         if (newRequest) {
             request = newRequest;

--- a/test/request_queue.js
+++ b/test/request_queue.js
@@ -142,6 +142,14 @@ describe('RequestQueue', () => {
             expect(await anotherQueue.isEmpty()).to.be.eql(true);
             expect(await anotherQueue.isFinished()).to.be.eql(true);
         });
+
+        it('should accept Request constructor object in addRequest()', async () => {
+            expectNotUsingLocalStorage();
+            const queue = new RequestQueue('some-id');
+            expect(() => {
+                queue.addRequest({ url: 'http://example.com/a' });
+            }).to.not.throw();
+        });
     });
 
     describe('remote', async () => {
@@ -426,6 +434,14 @@ describe('RequestQueue', () => {
 
             mock.verify();
             mock.restore();
+        });
+
+        it('should accept Request constructor object in addRequest()', async () => {
+            expectNotUsingLocalStorage();
+            const queue = new RequestQueue('some-id');
+            expect(() => {
+                queue.addRequest({ url: 'http://example.com/a' });
+            }).to.not.throw();
         });
     });
 


### PR DESCRIPTION
Hello,

Thought I'd help with improving the flexibility of `RequestQueue.addRequest` with an overload that accepts an object to construct a `Request`.

I haven't updated project-related documentation (i.e. README.md) or versioning as I'm unsure whether that's something left to maintainers to aggregate.