### PR TITLE
Add RequestList method to return handled requests count

### DIFF
--- a/src/request_list.js
+++ b/src/request_list.js
@@ -170,6 +170,8 @@ export default class RequestList {
         this.isLoading = false;
         this.isInitialized = false;
         this.sources = sources;
+
+        this._handledRequestsCount = 0;
     }
 
     /**
@@ -370,6 +372,8 @@ export default class RequestList {
 
                 delete this.inProgress[uniqueKey];
                 this.isStatePersisted = false;
+
+                this._handledRequestsCount++;
             });
     }
 
@@ -500,5 +504,14 @@ export default class RequestList {
      */
     length() {
         return this.requests.length;
+    }
+
+    /**
+     * Returns the total number of requests that have been marked as handled.
+     *
+     * @returns {number}
+     */
+    handledRequestsCount() {
+        return this._handledRequestsCount;
     }
 }

--- a/test/request_list.js
+++ b/test/request_list.js
@@ -550,4 +550,20 @@ describe('Apify.RequestList', () => {
 
         log.restore();
     });
+
+    it('should correctly return the number of handled requests with handledRequestsCount()', async () => {
+        const sources = [
+            { url: 'https://example.com/1' },
+            { url: 'https://example.com/2' },
+            { url: 'https://example.com/3' },
+        ];
+        const requestList = new Apify.RequestList({ sources });
+        await requestList.initialize();
+        const requests = await Promise.all(sources.map(async () => requestList.fetchNextRequest()));
+        expect(requestList.handledRequestsCount()).to.be.eql(0);
+        await requestList.markRequestHandled(requests[0]);
+        await requestList.markRequestHandled(requests[1]);
+        await requestList.markRequestHandled(requests[2]);
+        expect(requestList.handledRequestsCount()).to.be.eql(3);
+    });
 });


### PR DESCRIPTION
Hello,

Just another pull request to help introduce a simple count for tracking handled requests on `RequestList`.

As mentioned with my other recent pull request, if there's any other changes necessary, please advise.