### PR TITLE
Improve the logging of request.pushErrorMessage

### DIFF
--- a/docs/api/Request.md
+++ b/docs/api/Request.md
@@ -184,6 +184,13 @@ to override the default behavior and specify which URLs shall be considered equa
 ## `request.pushErrorMessage(errorOrMessage)`
 Stores information about an error that occurred during processing of this request.
 
+You should always use Error instances when throwing errors in JavaScript.
+
+Nevertheless, to improve the debugging experience when using third party libraries
+that may not always throw an Error instance, the function performs a type
+inspection of the passed argument and attempts to extract as much information
+as possible, since just throwing a bad type error makes any debugging rather difficult.
+
 <table>
 <thead>
 <tr>

--- a/src/request.js
+++ b/src/request.js
@@ -170,8 +170,12 @@ class Request {
         case 'object':
             if (!errorOrMessage) {
                 message = 'Received: "null" instead of a proper message.';
+            } else if (Array.isArray(errorOrMessage)) {
+                message = `Received: "array" instead of a proper message.\nContents: ${errorOrMessage}`;
             } else if (errorOrMessage.message) {
                 message = errorOrMessage.message; // eslint-disable-line prefer-destructuring
+            } else if (errorOrMessage.toString() !== '[object Object]') {
+                message = errorOrMessage.toString();
             } else {
                 try {
                     message = JSON.stringify(errorOrMessage, null, 2);

--- a/src/request.js
+++ b/src/request.js
@@ -167,8 +167,8 @@ class Request {
             } else if (errorOrMessage instanceof Error) {
                 message = omitStack
                     ? errorOrMessage.message
-                    // Use inspect because .toString() just returns the message.
-                    : util.inspect(errorOrMessage);
+                    // .stack includes the message
+                    : errorOrMessage.stack;
             } else if (errorOrMessage.message) {
                 message = errorOrMessage.message; // eslint-disable-line prefer-destructuring
             } else if (errorOrMessage.toString() !== '[object Object]') {

--- a/src/request.js
+++ b/src/request.js
@@ -154,13 +154,21 @@ class Request {
      * as possible, since just throwing a bad type error makes any debugging rather difficult.
      *
      * @param {Error|String} errorOrMessage Error object or error message to be stored in the request.
+     * @param {Object} [options]
+     * @param {Boolean} [options.omitStack=false] Only push the error message without stack trace when true.
      */
-    pushErrorMessage(errorOrMessage) {
+    pushErrorMessage(errorOrMessage, options = {}) {
+        const { omitStack } = options;
         let message;
         const type = typeof errorOrMessage;
         if (type === 'object') {
             if (!errorOrMessage) {
                 message = 'null';
+            } else if (errorOrMessage instanceof Error) {
+                message = omitStack
+                    ? errorOrMessage.message
+                    // Use inspect because .toString() just returns the message.
+                    : util.inspect(errorOrMessage);
             } else if (errorOrMessage.message) {
                 message = errorOrMessage.message; // eslint-disable-line prefer-destructuring
             } else if (errorOrMessage.toString() !== '[object Object]') {

--- a/test/request.js
+++ b/test/request.js
@@ -18,7 +18,7 @@ describe('Apify.Request', () => {
         expect(normalizedUrl).to.not.eql(url);
     });
 
-    it('should should allow to push error messages', () => {
+    it('should allow to push error messages', () => {
         const request = new Apify.Request({ url: 'http://example.com' });
 
         expect(request.errorMessages).to.be.eql(null);
@@ -69,7 +69,7 @@ describe('Apify.Request', () => {
 
         request.pushErrorMessage(new Error('error message.'));
         const last = request.errorMessages.pop();
-        expect(last).to.include('error message');
+        expect(last).to.include('error message.');
         expect(last).to.include(' at ');
         expect(last).to.include(__filename.split(/[\\/]/g).pop());
     });

--- a/test/request.js
+++ b/test/request.js
@@ -27,10 +27,15 @@ describe('Apify.Request', () => {
         circularObj.obj = circularObj;
 
         const arr = [1, 2, 3];
-        const arrJson = JSON.stringify(arr, null, 2);
 
         const obj = { one: 1, two: 'two' };
         const objJson = JSON.stringify(obj, null, 2);
+
+        const toStr = {
+            toString() {
+                return 'toString';
+            },
+        };
 
         request.pushErrorMessage(undefined);
         request.pushErrorMessage(false);
@@ -43,6 +48,7 @@ describe('Apify.Request', () => {
         request.pushErrorMessage({ message: 'A message.' });
         request.pushErrorMessage([1, 2, 3]);
         request.pushErrorMessage(obj);
+        request.pushErrorMessage(toStr);
         request.pushErrorMessage(circularObj);
 
         expect(request.errorMessages).to.be.eql([
@@ -55,8 +61,9 @@ describe('Apify.Request', () => {
             'Received: "null" instead of a proper message.',
             'foo',
             'A message.',
-            arrJson,
+            `Received: "array" instead of a proper message.\nContents: ${arr}`,
             objJson,
+            'toString',
             'Received an Object that is not stringifiable to JSON and has the following keys: prop; obj',
         ]);
     });

--- a/test/request.js
+++ b/test/request.js
@@ -1,3 +1,4 @@
+import util from 'util';
 import { expect } from 'chai';
 import { computeUniqueKey } from '../build/request';
 import Apify from '../build/index';
@@ -25,11 +26,10 @@ describe('Apify.Request', () => {
         // Make a circular, unstringifiable object.
         const circularObj = { prop: 1 };
         circularObj.obj = circularObj;
-
-        const arr = [1, 2, 3];
+        const circularObjInspect = util.inspect(circularObj);
 
         const obj = { one: 1, two: 'two' };
-        const objJson = JSON.stringify(obj, null, 2);
+        const objInspect = util.inspect(obj);
 
         const toStr = {
             toString() {
@@ -52,19 +52,19 @@ describe('Apify.Request', () => {
         request.pushErrorMessage(circularObj);
 
         expect(request.errorMessages).to.be.eql([
-            'Received: "undefined" of type: "undefined" instead of a proper message.',
-            'Received: "false" of type: "boolean" instead of a proper message.',
-            'Received: "5" of type: "number" instead of a proper message.',
-            'Received: "() => 2" of type: "function" instead of a proper message.',
+            'undefined',
+            'false',
+            '5',
+            '() => 2',
             'bar',
             'Symbol(A Symbol)',
-            'Received: "null" instead of a proper message.',
+            'null',
             'foo',
             'A message.',
-            `Received: "array" instead of a proper message.\nContents: ${arr}`,
-            objJson,
+            '1,2,3',
+            objInspect,
             'toString',
-            'Received an Object that is not stringifiable to JSON and has the following keys: prop; obj',
+            circularObjInspect,
         ]);
     });
 

--- a/test/request.js
+++ b/test/request.js
@@ -44,7 +44,7 @@ describe('Apify.Request', () => {
         request.pushErrorMessage('bar');
         request.pushErrorMessage(Symbol('A Symbol'));
         request.pushErrorMessage(null);
-        request.pushErrorMessage(new Error('foo'));
+        request.pushErrorMessage(new Error('foo'), { omitStack: true });
         request.pushErrorMessage({ message: 'A message.' });
         request.pushErrorMessage([1, 2, 3]);
         request.pushErrorMessage(obj);
@@ -66,6 +66,12 @@ describe('Apify.Request', () => {
             'toString',
             circularObjInspect,
         ]);
+
+        request.pushErrorMessage(new Error('error message.'));
+        const last = request.errorMessages.pop();
+        expect(last).to.include('error message');
+        expect(last).to.include(' at ');
+        expect(last).to.include(__filename.split(/[\\/]/g).pop());
     });
 
     it('should should allow to have a GET request with payload', () => {

--- a/test/request.js
+++ b/test/request.js
@@ -22,10 +22,43 @@ describe('Apify.Request', () => {
 
         expect(request.errorMessages).to.be.eql(null);
 
-        request.pushErrorMessage(new Error('foo'));
-        request.pushErrorMessage('bar');
+        // Make a circular, unstringifiable object.
+        const circularObj = { prop: 1 };
+        circularObj.obj = circularObj;
 
-        expect(request.errorMessages).to.be.eql(['foo', 'bar']);
+        const arr = [1, 2, 3];
+        const arrJson = JSON.stringify(arr, null, 2);
+
+        const obj = { one: 1, two: 'two' };
+        const objJson = JSON.stringify(obj, null, 2);
+
+        request.pushErrorMessage(undefined);
+        request.pushErrorMessage(false);
+        request.pushErrorMessage(5);
+        request.pushErrorMessage(() => 2);
+        request.pushErrorMessage('bar');
+        request.pushErrorMessage(Symbol('A Symbol'));
+        request.pushErrorMessage(null);
+        request.pushErrorMessage(new Error('foo'));
+        request.pushErrorMessage({ message: 'A message.' });
+        request.pushErrorMessage([1, 2, 3]);
+        request.pushErrorMessage(obj);
+        request.pushErrorMessage(circularObj);
+
+        expect(request.errorMessages).to.be.eql([
+            'Received: "undefined" of type: "undefined" instead of a proper message.',
+            'Received: "false" of type: "boolean" instead of a proper message.',
+            'Received: "5" of type: "number" instead of a proper message.',
+            'Received: "() => 2" of type: "function" instead of a proper message.',
+            'bar',
+            'Symbol(A Symbol)',
+            'Received: "null" instead of a proper message.',
+            'foo',
+            'A message.',
+            arrJson,
+            objJson,
+            'Received an Object that is not stringifiable to JSON and has the following keys: prop; obj',
+        ]);
     });
 
     it('should should allow to have a GET request with payload', () => {


### PR DESCRIPTION
One of users reported an "error" in one of their actors that was quite impossible to debug, due to the error being swallowed by a `TypeError` thrown from `request.pushErrorMessage`, since apparently the "error" passed to it was neither an instance of `Error`, nor a `String`.

This PR removes this `TypeError` and instead implements a set of type checks that attempt to extract infomation from all possible arguments that may have been passed `request.pushErrorMessage`.

This is useful in two ways. First of all, it improves the debugging experience. Secondly it prevents the possible `TypeError` from crashing the `AutoscaledPool` by rejecting a `runTaskFunction()` promise.