### PR TITLE
Fix overflowing offset in local dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+xxx
+===================
+- Fixed an issue where an error would be thrown when `datasetLocal.getData()` was invoked
+  with an overflowing offset. It now correctly returns an empty `Array`.
+
 0.9.15 / 2018-11-30
 ===================
 - Upgraded Puppeteer to 1.11.0

--- a/src/dataset.js
+++ b/src/dataset.js
@@ -584,11 +584,10 @@ export class DatasetLocal {
      */
     _getItemIndexes(offset = 0, limit = this.counter) {
         if (limit === null) throw new Error('DatasetLocal must be initialize before calling this._getItemIndexes()!');
-
-        return _.range(
-            offset + 1,
-            Math.min(offset + limit, this.counter) + 1,
-        );
+        const start = offset + 1;
+        const end = Math.min(offset + limit, this.counter) + 1;
+        if (start > end) return [];
+        return _.range(start, end);
     }
 
     /**

--- a/test/dataset.js
+++ b/test/dataset.js
@@ -107,6 +107,14 @@ describe('dataset', () => {
                 count: 2,
                 limit: 2,
             });
+
+            expect(await dataset.getData({ offset: 10 })).to.be.eql({
+                items: [],
+                total: 4,
+                offset: 10,
+                count: 0,
+                limit: LOCAL_GET_ITEMS_DEFAULT_LIMIT,
+            });
         });
 
         it('getInfo() should work', async () => {


### PR DESCRIPTION
`datasetLocal.getData()` now correctly returns `[]` for an overflowing offset.

Fixes: https://github.com/apifytech/apify-js/issues/250