### PR TITLE
Load handledRequestCount from storages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ xxx
 - Bugfix: PuppeteerPool was incorrectly overriding `proxyUrls` even if they were not defined.
 - Fixed an issue where an error would be thrown when `datasetLocal.getData()` was invoked
   with an overflowing offset. It now correctly returns an empty `Array`.
+- Fixed an issue where `maxRequestsPerCrawl` option would not be honored after restart or migration.
 
 0.9.15 / 2018-11-30
 ===================

--- a/src/basic_crawler.js
+++ b/src/basic_crawler.js
@@ -5,7 +5,6 @@ import { checkParamPrototypeOrThrow } from 'apify-shared/utilities';
 import AutoscaledPool from './autoscaling/autoscaled_pool';
 import RequestList from './request_list';
 import { RequestQueue, RequestQueueLocal } from './request_queue';
-import { apifyClient } from './utils';
 
 const DEFAULT_OPTIONS = {
     maxRequestRetries: 3,

--- a/src/basic_crawler.js
+++ b/src/basic_crawler.js
@@ -361,8 +361,7 @@ class BasicCrawler {
      */
     async _loadHandledRequestCount() {
         if (this.requestQueue) {
-            const queueInfo = await apifyClient.requestQueues.getQueue({ queueId: this.requestQueue.queueId });
-            this.handledRequestsCount = queueInfo.handledRequestCount;
+            this.handledRequestsCount = await this.requestQueue.handledCount();
         } else if (this.requestList) {
             this.handledRequestsCount = this.requestList.handledCount();
         }

--- a/src/request_queue.js
+++ b/src/request_queue.js
@@ -550,6 +550,16 @@ export class RequestQueue {
                 if (this.queueName) queuesCache.remove(this.queueName);
             });
     }
+
+    /**
+     * Returns the number of handled requests.
+     *
+     * @return {Promise<number>}
+     */
+    async handledCount() {
+        const queueInfo = await requestQueues.getQueue({ queueId: this.queueId });
+        return queueInfo.handledRequestCount;
+    }
 }
 
 /**
@@ -582,6 +592,7 @@ export class RequestQueueLocal {
 
         this.queueOrderNoCounter = 0; // Counter used in _getQueueOrderNo to ensure there won't be a collision.
         this.pendingCount = 0;
+        this._handledCount = 0;
         this.inProgressCount = 0;
         this.requestIdToQueueOrderNo = {};
         this.queueOrderNoInProgress = {};
@@ -600,6 +611,7 @@ export class RequestQueueLocal {
         ]);
 
         this.pendingCount = pending.length;
+        this._handledCount = handled.length;
 
         const handledPaths = handled.map(filename => path.join(this.localHandledEmulationPath, filename));
         const pendingPaths = pending.map(filename => path.join(this.localPendingEmulationPath, filename));
@@ -762,6 +774,7 @@ export class RequestQueueLocal {
                     .then(() => renamePromised(source, dest))
                     .then(() => {
                         this.pendingCount--;
+                        this._handledCount++;
                         this.inProgressCount--;
                         delete this.queueOrderNoInProgress[queueOrderNo];
 
@@ -824,6 +837,11 @@ export class RequestQueueLocal {
             .then(() => {
                 queuesCache.remove(this.queueId);
             });
+    }
+
+    async handledCount() {
+        await this.initializationPromise;
+        return this._handledCount;
     }
 }
 

--- a/test/basic_crawler.js
+++ b/test/basic_crawler.js
@@ -287,6 +287,11 @@ describe('BasicCrawler', () => {
             handleRequestFunction,
         });
 
+        sinon.stub(Apify.client.requestQueues, 'getQueue')
+            .returns(Promise.resolve({
+                handledRequestCount: 0,
+            }));
+
         // It enqueues all requests from RequestList to RequestQueue.
         const mock = sinon.mock(requestQueue);
         mock.expects('addRequest')
@@ -378,6 +383,7 @@ describe('BasicCrawler', () => {
         expect(await requestList.isEmpty()).to.be.eql(true);
 
         mock.verify();
+        sinon.restore();
     });
 
     it('should say that task is not ready requestList is not set and requestQueue is empty', async () => {
@@ -397,6 +403,11 @@ describe('BasicCrawler', () => {
         const processed = [];
         const queue = [];
         let isFinished = false;
+
+        sinon.stub(Apify.client.requestQueues, 'getQueue')
+            .returns(Promise.resolve({
+                handledRequestCount: 0,
+            }));
 
         const basicCrawler = new Apify.BasicCrawler({
             requestQueue,
@@ -435,6 +446,7 @@ describe('BasicCrawler', () => {
         expect(processed.includes(request0, request1)).to.be.eql(true);
 
         mock.verify();
+        sinon.restore();
     });
 
     it('should support maxRequestsPerCrawl parameter', async () => {


### PR DESCRIPTION
`BasicCrawler` keeps a `handledRequestsCount` of handled requests. However, this number always started at `0`, so after migration or after restarting actor locally, the actual values from storages would not be used. This PR enforces this check on every `basicCrawler.run()`.