### PR TITLE
Add log messages to inform about the reasons why a crawler finished

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ xxx
 - Bugfix: PuppeteerPool was incorrectly overriding `proxyUrls` even if they were not defined.
 - Fixed an issue where an error would be thrown when `datasetLocal.getData()` was invoked
   with an overflowing offset. It now correctly returns an empty `Array`.
+- `BasicCrawler` (and therefore all Crawlers) now logs a message explaining why it finished.
 
 0.9.15 / 2018-11-30
 ===================

--- a/src/basic_crawler.js
+++ b/src/basic_crawler.js
@@ -168,7 +168,6 @@ class BasicCrawler {
         const isMaxPagesExceeded = () => maxRequestsPerCrawl && maxRequestsPerCrawl <= this.handledRequestsCount;
 
         const { isFinishedFunction } = autoscaledPoolOptions;
-        this.isFinishedFunction = isFinishedFunction || this._defaultIsFinishedFunction;
 
         const basicCrawlerAutoscaledPoolConfiguration = {
             minConcurrency,
@@ -191,14 +190,17 @@ class BasicCrawler {
                     return true;
                 }
 
-                const isFinished = await this.isFinishedFunction();
+                const isFinished = isFinishedFunction
+                    ? isFinishedFunction()
+                    : this._defaultIsFinishedFunction();
+
                 if (isFinished) {
-                    if (isFinishedFunction) {
-                        log.info('BasicCrawler: Crawler\'s custom isFinishedFunction() returned true, the Crawler will shut down.');
-                    } else {
-                        log.info('BasicCrawler: All the Crawler\'s storages are finished (empty and processed), the Crawler will shut down.');
-                    }
+                    const reason = isFinishedFunction
+                        ? 'BasicCrawler: Crawler\'s custom isFinishedFunction() returned true, the Crawler will shut down.'
+                        : 'BasicCrawler: All the requests from request list and/or request queue have been processed, the Crawler will shut down.';
+                    log.info(reason);
                 }
+
                 return isFinished;
             },
         };


### PR DESCRIPTION
Tackles https://github.com/apifytech/apify-js/issues/223

All Crawlers are based on `BasicCrawler`, which will finish when either the underlying `AutoscaledPool` finishes or when an error is thrown. We already log errors, so that's a non-issue. It can also be aborted, but we already log that too.

The `AutoscaledPool` finishes when the `isFinishedFunction` returns true. In `BasicCrawler`, it can be either the default function or a custom function. Both now have new log messages. Reaching max requests is also handled.

So I reckon that's all. If you have any other ideas, let me know.