### PR TITLE
Fix hanging timeouts in Cheerio and PuppeteerCrawler

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "build": "rm -rf ./build && babel src --out-dir build",
     "build-docs": "npm run clean && npm run build && node ./website/tools/build_docs.js",
     "build-readme": "node ./tools/build_readme.js",
-    "test": "npm run build &&  nyc --reporter=html --reporter=text mocha --timeout 60000 --compilers js:babel-core/register --recursive --exit",
+    "test": "npm run build &&  nyc --reporter=html --reporter=text mocha --timeout 60000 --compilers js:babel-core/register --recursive",
     "prepare": "npm run build",
     "prepublishOnly": "(test $RUNNING_FROM_SCRIPT || (echo \"You must use publish.sh instead of 'npm publish' directly!\"; exit 1)) && npm test && npm run lint",
     "clean": "rm -rf build",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "build": "rm -rf ./build && babel src --out-dir build",
     "build-docs": "npm run clean && npm run build && node ./website/tools/build_docs.js",
     "build-readme": "node ./tools/build_readme.js",
-    "test": "npm run build &&  nyc --reporter=html --reporter=text mocha --timeout 60000 --compilers js:babel-core/register --recursive",
+    "test": "npm run build &&  nyc --reporter=html --reporter=text mocha --timeout 60000 --require babel-core/register --recursive --exit",
     "prepare": "npm run build",
     "prepublishOnly": "(test $RUNNING_FROM_SCRIPT || (echo \"You must use publish.sh instead of 'npm publish' directly!\"; exit 1)) && npm test && npm run lint",
     "clean": "rm -rf build",

--- a/src/puppeteer_crawler.js
+++ b/src/puppeteer_crawler.js
@@ -3,7 +3,7 @@ import log from 'apify-shared/log';
 import _ from 'underscore';
 import BasicCrawler from './basic_crawler';
 import PuppeteerPool from './puppeteer_pool';
-import { createTimeoutPromise } from './utils';
+import { addTimeoutToPromise } from './utils';
 
 const DEFAULT_OPTIONS = {
     gotoFunction: async ({ request, page }) => page.goto(request.url, { timeout: 60000 }),
@@ -234,7 +234,7 @@ class PuppeteerCrawler {
         this.gotoFunction = gotoFunction;
 
         if (pageOpsTimeoutMillis) log.warning('options.pageOpsTimeoutMillis is deprecated, use options.handlePageTimeoutSecs instead.');
-        this.handlePageTimeoutSecs = handlePageTimeoutSecs || Math.ceil(pageOpsTimeoutMillis / 1000);
+        this.handlePageTimeoutMillis = handlePageTimeoutSecs * 1000 || pageOpsTimeoutMillis;
 
         this.puppeteerPoolOptions = {
             maxOpenPagesPerInstance,
@@ -246,7 +246,7 @@ class PuppeteerCrawler {
             launchPuppeteerOptions,
         };
 
-        this.puppeteerPool = new PuppeteerPool(this.puppeteerPoolOptions);
+        this.puppeteerPool = null; // Constructed when .run()
 
         this.basicCrawler = new BasicCrawler({
             // Basic crawler options.
@@ -311,19 +311,18 @@ class PuppeteerCrawler {
         try {
             const pageOperationsPromise = this
                 .gotoFunction({ page, request, puppeteerPool: this.puppeteerPool })
-                .then((response) => {
-                    return Promise.race([
-                        this.handlePageFunction({ page, request, puppeteerPool: this.puppeteerPool, response }),
-                        createTimeoutPromise(this.handlePageTimeoutSecs * 1000, 'PuppeteerCrawler: handlePageFunction timed out.'),
-                    ]);
-                });
+                .then(response => addTimeoutToPromise(
+                    this.handlePageFunction({ page, request, puppeteerPool: this.puppeteerPool, response }),
+                    this.handlePageTimeoutMillis,
+                    'PuppeteerCrawler: handlePageFunction timed out.',
+                ));
 
             // rejectOnAbortPromise rejects when .abort() is called or BasicCrawler throws.
             // All running pages are therefore terminated with an error to be reclaimed and retried.
             return await Promise.race([pageOperationsPromise, this.rejectOnAbortPromise]);
         } finally {
             try {
-                await Promise.race([page.close(), createTimeoutPromise(PAGE_CLOSE_TIMEOUT_MILLIS, 'Operation timed out.')]);
+                await addTimeoutToPromise(page.close(), PAGE_CLOSE_TIMEOUT_MILLIS, 'Operation timed out.');
             } catch (err) {
                 log.debug('PuppeteerCrawler: Page.close() failed.', { reason: err && err.message });
             }

--- a/src/puppeteer_live_view_server.js
+++ b/src/puppeteer_live_view_server.js
@@ -310,7 +310,10 @@ export default class PuppeteerLiveViewServer extends EventEmitter {
     addBrowser(browser) {
         this.browsers.add(browser);
         this.emit('browsercreated', browser);
-        browser.on('disconnected', () => this.deleteBrowser(browser));
+        browser.on('disconnected', () => {
+            this.deleteBrowser(browser);
+            if (!this.browsers.size) this.httpServer.close();
+        });
     }
 
     /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -316,6 +316,7 @@ export const getTypicalChromeExecutablePath = () => {
  * @param {Promise} promise
  * @param {number} timeoutMillis
  * @param {string} errorMessage
+ * @ignore
  */
 export const addTimeoutToPromise = (promise, timeoutMillis, errorMessage) => {
     return new Promise((resolve, reject) => {

--- a/test/autoscaling/snapshotter.js
+++ b/test/autoscaling/snapshotter.js
@@ -1,12 +1,13 @@
 import { expect } from 'chai';
+import sinon from 'sinon';
 import log from 'apify-shared/log';
 import { ACTOR_EVENT_NAMES, ENV_VARS } from 'apify-shared/consts';
 import * as Apify from '../../build/index';
 import events from '../../build/events';
 import Snapshotter from '../../build/autoscaling/snapshotter';
-import { apifyClient } from '../../build/utils';
+import * as utils from '../../build/utils';
 
-// const toBytes = x => x * 1024 * 1024;
+const toBytes = x => x * 1024 * 1024;
 
 describe('Snapshotter', () => {
     let logLevel;
@@ -21,15 +22,15 @@ describe('Snapshotter', () => {
 
     it('should collect snapshots with some values', async () => {
         // mock client data
-        const oldStats = apifyClient.stats;
-        apifyClient.stats = {};
-        apifyClient.stats.rateLimitErrors = 0;
+        const oldStats = utils.apifyClient.stats;
+        utils.apifyClient.stats = {};
+        utils.apifyClient.stats.rateLimitErrors = 0;
 
         const snapshotter = new Snapshotter();
         await snapshotter.start();
 
         await Apify.utils.sleep(625);
-        apifyClient.stats.rateLimitErrors = 2;
+        utils.apifyClient.stats.rateLimitErrors = 2;
         await Apify.utils.sleep(625);
 
         await snapshotter.stop();
@@ -69,7 +70,7 @@ describe('Snapshotter', () => {
             expect(ss.rateLimitErrorCount).to.be.a('number');
         });
 
-        apifyClient.stats = oldStats;
+        utils.apifyClient.stats = oldStats;
     });
 
     it('should override default timers', async () => {
@@ -158,58 +159,65 @@ describe('Snapshotter', () => {
         expect(overloadedCount).to.be.above(0);
     });
 
-    /*
-    TODO: Fix this test. It's failing under load when the 2nd snapshot happens in the second half of the time
-          or the third one doesn't happen at all.
-    it('correctly marks memoryOverloaded', async () => {
-        process.env[ENV_VARS.MEMORY_MBYTES] = 20;
-        const options = {
-            memorySnapshotIntervalSecs: 0.1,
+    it('correctly marks memoryOverloaded', async () => { /* eslint-disable no-underscore-dangle */
+        const noop = () => {};
+        const memoryData = {
+            mainProcessBytes: toBytes(1000),
+            childProcessesBytes: toBytes(1000),
         };
+        const getMem = async () => Object.assign({}, memoryData);
+        const stub = sinon.stub(utils, 'getMemoryInfo');
+        stub.callsFake(getMem);
 
-        const snapshotter = new Snapshotter(options);
-        await snapshotter.start();
-        await Apify.utils.sleep(199);
-        snapshotter.maxMemoryBytes = toBytes(1000); // Override memory to get an OK reading.
-        await Apify.utils.sleep(199);
-        await snapshotter.stop();
+        process.env[ENV_VARS.MEMORY_MBYTES] = '10000';
+
+        const snapshotter = new Snapshotter({ maxUsedMemoryRatio: 0.5 });
+        await snapshotter._snapshotMemory(noop);
+        memoryData.mainProcessBytes = toBytes(2000);
+        await snapshotter._snapshotMemory(noop);
+        memoryData.childProcessesBytes = toBytes(2000);
+        await snapshotter._snapshotMemory(noop);
+        memoryData.mainProcessBytes = toBytes(3001);
+        await snapshotter._snapshotMemory(noop);
+        memoryData.childProcessesBytes = toBytes(1999);
+        await snapshotter._snapshotMemory(noop);
         const memorySnapshots = snapshotter.getMemorySample();
 
-        expect(memorySnapshots.length).to.be.above(2);
-        expect(memorySnapshots[0].isOverloaded).to.be.eql(true);
-        expect(memorySnapshots[1].isOverloaded).to.be.eql(true);
+        expect(memorySnapshots.length).to.be.eql(5);
+        expect(memorySnapshots[0].isOverloaded).to.be.eql(false);
+        expect(memorySnapshots[1].isOverloaded).to.be.eql(false);
         expect(memorySnapshots[2].isOverloaded).to.be.eql(false);
+        expect(memorySnapshots[3].isOverloaded).to.be.eql(true);
+        expect(memorySnapshots[4].isOverloaded).to.be.eql(false);
+
         delete process.env[ENV_VARS.MEMORY_MBYTES];
     });
-    */
 
-    it('correctly marks clientOverloaded', async () => {
+    it('correctly marks clientOverloaded', async () => { /* eslint-disable no-underscore-dangle */
+        const noop = () => {};
         // mock client data
-        const oldStats = apifyClient.stats;
-        apifyClient.stats = {};
-        apifyClient.stats.rateLimitErrors = 0;
+        const oldStats = utils.apifyClient.stats;
+        utils.apifyClient.stats = {};
+        utils.apifyClient.stats.rateLimitErrors = 0;
 
-        const options = {
-            clientSnapshotIntervalSecs: 0.001,
-        };
+        const snapshotter = new Snapshotter();
+        snapshotter._snapshotClient(noop);
+        utils.apifyClient.stats.rateLimitErrors = 1;
+        snapshotter._snapshotClient(noop);
+        utils.apifyClient.stats.rateLimitErrors = 2;
+        snapshotter._snapshotClient(noop);
+        utils.apifyClient.stats.rateLimitErrors = 4;
+        snapshotter._snapshotClient(noop);
 
-        const snapshotter = new Snapshotter(options);
-        await snapshotter.start();
-        apifyClient.stats.rateLimitErrors = 1;
-        await Apify.utils.sleep(1);
-        apifyClient.stats.rateLimitErrors = 2;
-        await Apify.utils.sleep(1);
-        apifyClient.stats.rateLimitErrors = 10000;
-        await Apify.utils.sleep(1);
-        await snapshotter.stop();
         const clientSnapshots = snapshotter.getClientSample();
 
-        expect(clientSnapshots.length).to.be.above(2);
+        expect(clientSnapshots.length).to.be.eql(4);
         expect(clientSnapshots[0].isOverloaded).to.be.eql(false);
         expect(clientSnapshots[1].isOverloaded).to.be.eql(false);
-        expect(clientSnapshots[clientSnapshots.length - 1].isOverloaded).to.be.eql(true);
+        expect(clientSnapshots[2].isOverloaded).to.be.eql(false);
+        expect(clientSnapshots[3].isOverloaded).to.be.eql(true);
 
-        apifyClient.stats = oldStats;
+        utils.apifyClient.stats = oldStats;
     });
 
     it('.get[.*]Sample limits amount of samples', async () => {

--- a/test/events.js
+++ b/test/events.js
@@ -1,7 +1,6 @@
 import 'babel-polyfill';
 import WebSocket from 'ws';
 import sinon from 'sinon';
-import Promise from 'bluebird';
 import { expect } from 'chai';
 import { delayPromise } from 'apify-shared/utilities';
 import { ENV_VARS } from 'apify-shared/consts';

--- a/test/puppeteer_live_view_server.js
+++ b/test/puppeteer_live_view_server.js
@@ -1,6 +1,5 @@
 import http from 'http';
 import { expect, assert } from 'chai';
-import Promise from 'bluebird';
 import puppeteer from 'puppeteer';
 import { ENV_VARS } from 'apify-shared/consts';
 import Apify from '../build/index';

--- a/test/utils.js
+++ b/test/utils.js
@@ -4,7 +4,6 @@ import sinon from 'sinon';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-import Promise from 'bluebird';
 import requestPromise from 'request-promise-native';
 import LruCache from 'apify-shared/lru_cache';
 import { ENV_VARS, LOCAL_ENV_VARS } from 'apify-shared/consts';

--- a/test/webdriver.js
+++ b/test/webdriver.js
@@ -2,9 +2,9 @@ import _ from 'underscore';
 import { expect, assert } from 'chai';
 import proxy from 'proxy';
 import http from 'http';
+import util from 'util';
 import portastic from 'portastic';
 import basicAuthParser from 'basic-auth-parser';
-import Promise from 'bluebird';
 // import fs from 'fs';
 
 import { processBrowseArgs, getDefaultBrowseOptions } from '../build/webdriver';
@@ -54,7 +54,7 @@ before(() => {
 
 after(function () {
     this.timeout(30 * 1000);
-    if (proxyServer) return Promise.promisify(proxyServer.close).bind(proxyServer)();
+    if (proxyServer) return util.promisify(proxyServer.close).bind(proxyServer)();
 });
 
 describe('getDefaultBrowseOptions()', () => {


### PR DESCRIPTION
Open timeout promises would prevent garbage collection of the data promises and kept the process running. This PR adds a new function that wraps the data promises so that the timeouts automatically cancel, plus it fixes some hanging issues in the tests, except `Apify.launchWebDriver`, that still hangs due to `proxy-chain` not being closed.

It also fixes some unrelated flaky tests.