### PR TITLE
Fix reusePages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 0.11.0 / 2018-01-07
 ===================
 - **BREAKING CHANGE:** `basicCrawler.abort()`, `cheerioCrawler.abort()` and `puppeteerCrawler.abort()` functions
-  were removed in favor of a single new `autoscaledPool.abort()` function.
+  were removed in favor of a single `autoscaledPool.abort()` function.
 
 - Added a reference to the running `AutoscaledPool` instance to the options object of `BasicCrawler`'s
   `handleRequestFunction` and to the `handlePageFunction` of `CheerioCrawler` and `PuppeteerCrawler`.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+xxx
+===================
+- Fix missing `reusePages` configuration parameter in `PuppeteerCrawler`.
+- Fix a memory leak where `reusePages` would prevent browsers from closing.
+
 0.11.1 / 2018-01-07
 ===================
 - Fix missing `autoscaledPool` parameter in `handlePageFunction` of `PuppeteerCrawler`.

--- a/src/puppeteer_crawler.js
+++ b/src/puppeteer_crawler.js
@@ -147,6 +147,10 @@ const PAGE_CLOSE_TIMEOUT_MILLIS = 30000;
  *   Maximum number of pages that the crawler will open. The crawl will stop when this limit is reached.
  *   Always set this value in order to prevent infinite loops in misconfigured crawlers.
  *   Note that in cases of parallel crawling, the actual number of pages visited might be slightly higher than this value.
+ * @param {boolean} [options.reusePages=false]
+ *   Individual browser tabs will be reused after their task is complete instead
+ *   of closing them and spawning a new tab. This saves CPU resources.
+ *   See `reusePages` parameter of {@link PuppeteerPool}.
  * @param {Number} [options.maxOpenPagesPerInstance=50]
  *   Maximum number of opened tabs per browser. If this limit is reached then a new
  *   browser instance is started. See `maxOpenPagesPerInstance` parameter of {@link PuppeteerPool}.
@@ -218,6 +222,7 @@ class PuppeteerCrawler {
 
             // PuppeteerPool options
             // TODO: We should put these into a single object, similarly to autoscaledPoolOptions
+            reusePages,
             maxOpenPagesPerInstance,
             retireInstanceAfterRequestCount,
             instanceKillerIntervalMillis,
@@ -238,6 +243,7 @@ class PuppeteerCrawler {
         this.handlePageTimeoutMillis = handlePageTimeoutSecs * 1000 || pageOpsTimeoutMillis;
 
         this.puppeteerPoolOptions = {
+            reusePages,
             maxOpenPagesPerInstance,
             retireInstanceAfterRequestCount,
             instanceKillerIntervalMillis,

--- a/src/puppeteer_pool.js
+++ b/src/puppeteer_pool.js
@@ -440,6 +440,10 @@ class PuppeteerPool {
                 this._incrementPageCount(instance);
                 return idlePage;
             }
+            // Close pages of retired instances so they don't keep hanging there forever.
+            if (pageIsNotClosed && !instanceIsActive) {
+                await idlePage.close();
+            }
         }
         // If there are no live pages to be reused, we spawn a new tab.
         return this._openNewTab();

--- a/test/puppeteer_pool.js
+++ b/test/puppeteer_pool.js
@@ -392,20 +392,16 @@ describe('PuppeteerPool', () => {
             let page = await pool.newPage();
             await pool.recyclePage(page);
             expect(len(pool.activeInstances)).to.be.eql(1);
-            expect(len(pool.retiredInstances)).to.be.eql(0);
 
             page = await pool.newPage();
             await pool.recyclePage(page);
             expect(len(pool.activeInstances)).to.be.eql(0);
-            expect(len(pool.retiredInstances)).to.be.eql(1);
 
             page = await pool.newPage();
             expect(len(pool.activeInstances)).to.be.eql(1);
-            expect(len(pool.retiredInstances)).to.be.eql(1);
 
             const pageTwo = await pool.newPage();
             expect(len(pool.activeInstances)).to.be.eql(0);
-            expect(len(pool.retiredInstances)).to.be.eql(2);
 
             await pool.recyclePage(page);
             await pool.recyclePage(pageTwo);
@@ -413,7 +409,6 @@ describe('PuppeteerPool', () => {
             await pool.newPage();
             expect(len(pool.activeInstances)).to.be.eql(1);
             await pool.newPage();
-            expect(len(pool.retiredInstances)).to.be.eql(3);
             expect(len(pool.activeInstances)).to.be.eql(0);
 
             await pool.destroy();


### PR DESCRIPTION
`reusePages` option was missing from `PuppeteerCrawler` and therefore could not be used. It was also leaking memory because browsers were not being closed due to open idle pages. This PR fixes both issues.