### PR TITLE
adding listKeys() function for cloud and local

### DIFF
--- a/src/key_value_store.js
+++ b/src/key_value_store.js
@@ -391,11 +391,11 @@ export class KeyValueStoreLocal {
      *
      * @ignore
      */
-    listKeys(options) {
+    listKeys() {
         return readdirPromised(this.localStoragePath)
             .then((files) => {
-                for (var i = 0; i < files.length; i++) {
-                    files[i] = {key:path.parse(files[i]).name}
+                for (let i = 0; i < files.length; i++) {
+                    files[i] = { key: path.parse(files[i]).name };
                 }
                 return {
                     items: files,
@@ -403,7 +403,7 @@ export class KeyValueStoreLocal {
                     limit: files.length,
                     isTruncated: false,
                     exclusiveStartKey: null,
-                    nextExclusiveStartKey: null
+                    nextExclusiveStartKey: null,
                 };
             });
     }

--- a/src/key_value_store.js
+++ b/src/key_value_store.js
@@ -292,10 +292,12 @@ export class KeyValueStore {
     }
 
     /**
-     * Returns a PaginationList up to 1000 items for a given store.
+     * Returns a PaginationList of the keys from the KeyValueStore.
+     * @param {Object} options
+     * @param {String} [options.exclusiveStartKey] - All keys up to this one (including) are skipped from the result.
+     * @param {Number} [options.limit] - Number of keys to be returned. Maximum value is 1000
+     * @returns {PaginationList}
      * @link https://www.apify.com/docs/api/apify-client-js/latest#ApifyClient-keyValueStores-listKeys
-     *
-     * @return {Promise}
      */
     listKeys(options) {
         const optionsDefaults = {

--- a/test/key_value_store.js
+++ b/test/key_value_store.js
@@ -367,4 +367,21 @@ describe('KeyValueStore', () => {
             mock.restore();
         });
     });
+
+    describe('listKeys', async () => {
+        //@todo create remote test without specifying private userID or storageID
+
+        it('should receive a PaginationList from local', async () => {
+            process.env[ENV_VARS.LOCAL_STORAGE_DIR] = await LOCAL_STORAGE_DIR;
+            process.env[ENV_VARS.TOKEN] = 'xxx';
+            const store = await Apify.openKeyValueStore('some-name-1');
+            await store.setValue('key-1', 'xxxx', { contentType: 'text/plain; charset=utf-8' });
+            await store.setValue('key-2', 'xxxx', { contentType: 'text/plain; charset=utf-8' });
+
+            const paginationList = await store.listKeys();
+            await expect(paginationList.count).to.eql(2);
+            await expect(paginationList.items[0].key).to.eql('key-1');
+            await expect(paginationList.items[1].key).to.eql('key-2');
+        });
+    });
 });

--- a/test/key_value_store.js
+++ b/test/key_value_store.js
@@ -369,12 +369,11 @@ describe('KeyValueStore', () => {
     });
 
     describe('listKeys', async () => {
-        //@todo create remote test without specifying private userID or storageID
-
+        // @todo create remote test without specifying private userID or storageID
         it('should receive a PaginationList from local', async () => {
             process.env[ENV_VARS.LOCAL_STORAGE_DIR] = await LOCAL_STORAGE_DIR;
             process.env[ENV_VARS.TOKEN] = 'xxx';
-            
+
             const store = await Apify.openKeyValueStore('some-name-1');
             await store.setValue('key-1', 'xxxx', { contentType: 'text/plain; charset=utf-8' });
             await store.setValue('key-2', 'xxxx', { contentType: 'text/plain; charset=utf-8' });

--- a/test/key_value_store.js
+++ b/test/key_value_store.js
@@ -374,6 +374,7 @@ describe('KeyValueStore', () => {
         it('should receive a PaginationList from local', async () => {
             process.env[ENV_VARS.LOCAL_STORAGE_DIR] = await LOCAL_STORAGE_DIR;
             process.env[ENV_VARS.TOKEN] = 'xxx';
+            
             const store = await Apify.openKeyValueStore('some-name-1');
             await store.setValue('key-1', 'xxxx', { contentType: 'text/plain; charset=utf-8' });
             await store.setValue('key-2', 'xxxx', { contentType: 'text/plain; charset=utf-8' });
@@ -382,6 +383,9 @@ describe('KeyValueStore', () => {
             await expect(paginationList.count).to.eql(2);
             await expect(paginationList.items[0].key).to.eql('key-1');
             await expect(paginationList.items[1].key).to.eql('key-2');
+
+            delete process.env[ENV_VARS.DEFAULT_KEY_VALUE_STORE_ID];
+            delete process.env[ENV_VARS.LOCAL_STORAGE_DIR];
         });
     });
 });


### PR DESCRIPTION
I managed to get a little time today for #277 and #249 -  add listKeys() for sdk.
Added tests for both local and cloud.  I removed the `forceCloud:true` test as I just tested with private userID/datastoreID and not sure if you really need that test anyway.