### PR TITLE
Request queue and key-value store fixes

### DIFF
--- a/test/_helper.js
+++ b/test/_helper.js
@@ -8,9 +8,10 @@ export const LOCAL_STORAGE_DIR = path.join(__dirname, '..', 'tmp', 'local-emulat
 // Log unhandled rejections.
 process.on('unhandledRejection', (err) => {
     console.log('---------------------------------------------------------------------');
-    console.log('------------- WARNING: Unhandled promise rejection !!!! -------------');
+    console.log('- ERROR: Killing tests because of unhandled promise rejection !!!!! -');
     console.log('---------------------------------------------------------------------');
     console.log(err);
+    process.exit(1);
 });
 
 // Immediately ensure that local emulation dir exists.

--- a/test/_helper.js
+++ b/test/_helper.js
@@ -7,9 +7,9 @@ export const LOCAL_STORAGE_DIR = path.join(__dirname, '..', 'tmp', 'local-emulat
 
 // Log unhandled rejections.
 process.on('unhandledRejection', (err) => {
-    console.log('---------------------------------------------------------------------');
-    console.log('- ERROR: Killing tests because of unhandled promise rejection !!!!! -');
-    console.log('---------------------------------------------------------------------');
+    console.log('----------------------------------------------------------------');
+    console.log('- ERROR: Exiting tests because of unhandled promise rejection! -');
+    console.log('----------------------------------------------------------------');
     console.log(err);
     process.exit(1);
 });

--- a/test/key_value_store.js
+++ b/test/key_value_store.js
@@ -212,6 +212,7 @@ describe('KeyValueStore', () => {
         it('throws on invalid args', async () => {
             process.env[ENV_VARS.DEFAULT_KEY_VALUE_STORE_ID] = '12345';
             process.env[ENV_VARS.LOCAL_STORAGE_DIR] = LOCAL_STORAGE_DIR;
+
             await expect(Apify.setValue()).to.be.rejectedWith('Parameter "key" of type String must be provided');
             await expect(Apify.setValue('', null)).to.be.rejectedWith('The "key" parameter cannot be empty');
             await expect(Apify.setValue('', 'some value')).to.be.rejectedWith('The "key" parameter cannot be empty');

--- a/test/request_queue.js
+++ b/test/request_queue.js
@@ -6,7 +6,10 @@ import path from 'path';
 import { ENV_VARS } from 'apify-shared/consts';
 import * as Apify from '../build/index';
 import * as utils from '../build/utils';
-import { RequestQueueLocal, RequestQueue, LOCAL_STORAGE_SUBDIR, QUERY_HEAD_MIN_LENGTH } from '../build/request_queue';
+import {
+    RequestQueueLocal, RequestQueue,
+    LOCAL_STORAGE_SUBDIR, QUERY_HEAD_MIN_LENGTH, MAX_QUERIES_FOR_CONSISTENCY, API_PROCESSED_REQUESTS_DELAY_MILLIS,
+} from '../build/request_queue';
 import { emptyLocalStorageSubdir, LOCAL_STORAGE_DIR, expectNotUsingLocalStorage, expectDirEmpty, expectDirNonEmpty } from './_helper';
 
 const { apifyClient } = utils;
@@ -191,11 +194,11 @@ describe('RequestQueue', () => {
         });
 
         it('should accept plain object in addRequest()', async () => {
-            expectNotUsingLocalStorage();
-            const queue = new RequestQueue('some-id');
-            expect(() => {
-                queue.addRequest({ url: 'http://example.com/a' });
-            }).to.not.throw();
+            const queue = new RequestQueueLocal('some-id', LOCAL_STORAGE_DIR);
+            await queue.addRequest({ url: 'http://example.com/a' });
+            expect(
+                (await queue.fetchNextRequest()).url
+            ).to.be.eql('http://example.com/a');
         });
 
         it('should return correct handledCount', async () => {
@@ -350,7 +353,7 @@ describe('RequestQueue', () => {
             mock.restore();
         });
 
-        it('should cache requests new locally', async () => {
+        it('should cache new requests locally', async () => {
             expectNotUsingLocalStorage();
 
             const { Request } = Apify;
@@ -560,9 +563,17 @@ describe('RequestQueue', () => {
         it('should accept plain object in addRequest()', async () => {
             expectNotUsingLocalStorage();
             const queue = new RequestQueue('some-id');
-            expect(() => {
-                queue.addRequest({ url: 'http://example.com/a' });
-            }).to.not.throw();
+            const mock = sinon.mock(apifyClient.requestQueues);
+            mock.expects('addRequest')
+                .once()
+                .returns(Promise.resolve({
+                    requestId: 'xxx',
+                    wasAlreadyHandled: false,
+                    wasAlreadyPresent: false,
+                }))
+            await queue.addRequest({ url: 'http://example.com/a' });
+            mock.verify();
+            mock.restore();
         });
 
         it('should return correct handledCount', async () => {
@@ -577,9 +588,48 @@ describe('RequestQueue', () => {
             sinon.assert.callCount(stub, 1);
             sinon.restore();
         });
+
+        it('should always wait for a queue head to become consistent before marking queue as finished', async () => {
+            expectNotUsingLocalStorage();
+
+            const queue = new RequestQueue('some-id', 'some-name');
+            const mock = sinon.mock(apifyClient.requestQueues);
+
+            // Return head with modifiedAt = now so it will retry the call.
+            mock.expects('getHead')
+                .once()
+                .withArgs({
+                    queueId: 'some-id',
+                    limit: QUERY_HEAD_MIN_LENGTH,
+                })
+                .returns(Promise.resolve({
+                    limit: 5,
+                    queueModifiedAt: new Date(),
+                    items: [],
+                }));
+
+            // And now return return date which makes the queue consistent.
+            mock.expects('getHead')
+                .once()
+                .withArgs({
+                    queueId: 'some-id',
+                    limit: QUERY_HEAD_MIN_LENGTH,
+                })
+                .returns(Promise.resolve({
+                    limit: 5,
+                    queueModifiedAt: new Date(Date.now() - API_PROCESSED_REQUESTS_DELAY_MILLIS),
+                    items: [],
+                }));
+
+            expect(await queue.isFinished()).to.be.eql(true);
+
+            mock.verify();
+            mock.restore();
+        });
     });
 
     describe('Apify.openRequestQueue', async () => {
+        return;
         it('should work', () => {
             const mock = sinon.mock(utils);
 

--- a/test/request_queue.js
+++ b/test/request_queue.js
@@ -8,7 +8,7 @@ import * as Apify from '../build/index';
 import * as utils from '../build/utils';
 import {
     RequestQueueLocal, RequestQueue,
-    LOCAL_STORAGE_SUBDIR, QUERY_HEAD_MIN_LENGTH, MAX_QUERIES_FOR_CONSISTENCY, API_PROCESSED_REQUESTS_DELAY_MILLIS,
+    LOCAL_STORAGE_SUBDIR, QUERY_HEAD_MIN_LENGTH, API_PROCESSED_REQUESTS_DELAY_MILLIS,
 } from '../build/request_queue';
 import { emptyLocalStorageSubdir, LOCAL_STORAGE_DIR, expectNotUsingLocalStorage, expectDirEmpty, expectDirNonEmpty } from './_helper';
 
@@ -197,7 +197,7 @@ describe('RequestQueue', () => {
             const queue = new RequestQueueLocal('some-id', LOCAL_STORAGE_DIR);
             await queue.addRequest({ url: 'http://example.com/a' });
             expect(
-                (await queue.fetchNextRequest()).url
+                (await queue.fetchNextRequest()).url,
             ).to.be.eql('http://example.com/a');
         });
 
@@ -570,7 +570,7 @@ describe('RequestQueue', () => {
                     requestId: 'xxx',
                     wasAlreadyHandled: false,
                     wasAlreadyPresent: false,
-                }))
+                }));
             await queue.addRequest({ url: 'http://example.com/a' });
             mock.verify();
             mock.restore();
@@ -629,7 +629,6 @@ describe('RequestQueue', () => {
     });
 
     describe('Apify.openRequestQueue', async () => {
-        return;
         it('should work', () => {
             const mock = sinon.mock(utils);
 


### PR DESCRIPTION
* there was bug in retrying of getHead() requests in request queue to ensure consistency when (Date.now() - queue.modifiedAt < 10s)
* there were multiple bugs in key value store causing unhandled promise rejections when running tests
* I also updated tests to exit with 1 on any unhandled promise rejection