### PR TITLE
Feature/upgrade puppeteer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ xxx
   in order to prevent stalling crawlers.
 - **BREAKING CHANGE:** `PseudoUrl` now performs case-insensitive matching, even for the query string part of the URLs.
   If you need case sensitive matching, use an appropriate `RegExp` in place of a Pseudo URL string
-- **Upgraded to Puppeteer version 1.12.2**
+- **Upgraded to puppeteer@1.12.2** and xregexp@4.2.4
 - Added `loadedUrl` property to `Request` that contains the final URL of the loaded page after all redirects.
 - Added memory overload warning log message.
 - Added `keyValueStore.getPublicUrl` function.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ xxx
   in order to prevent stalling crawlers.
 - **BREAKING CHANGE:** `PseudoUrl` now performs case-insensitive matching, even for the query string part of the URLs.
   If you need case sensitive matching, use an appropriate `RegExp` in place of a Pseudo URL string
+- **Upgraded to Puppeteer version 1.12.2**
 - Added `loadedUrl` property to `Request` that contains the final URL of the loaded page after all redirects.
 - Added memory overload warning log message.
 - Added `keyValueStore.getPublicUrl` function.

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "why-is-node-running": "^2.0.3"
   },
   "optionalDependencies": {
-    "puppeteer": "1.11.0",
+    "puppeteer": "1.12.2",
     "selenium-webdriver": "^3.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "rimraf": "^2.6.2",
     "underscore": "^1.9.1",
     "ws": "^6.1.2",
-    "xregexp": "4.2.0"
+    "xregexp": "^4.2.4"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",


### PR DESCRIPTION
It seems Puppeteer fixed that issue with opening example.com, we can upgrade to latest version - https://github.com/GoogleChrome/puppeteer/releases