### PR TITLE
Add timeouts to puppeteer operations (and other fixes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+xxx
+===================
+- **BREAKING CHANGE:** Added `puppeteerOperationTimeoutSecs` option to `PuppeteerPool`.
+  It defaults to 15 seconds and all Puppeteer operations such as `browser.newPage()`
+  or `puppeteer.launch()` will now time out. This is to prevent hanging requests.
+- **BREAKING CHANGE:** Added `handleRequestTimeoutSecs` option to `BasicCrawler` with a 60 second default.
+- `CheerioCrawler` and `PuppeteerCrawler` now automatically set `handleRequestTimeoutSecs` to double of
+  `handlePageTimeoutSecs`.
+- `puppeteerPool.newPage()` now retries twice before throwing an error.
+
 0.12.2 / 2019-02-27
 ===================
 - Added oldest active tab focusing to `PuppeteerPool` to combat resource throttling in Chromium.

--- a/src/cheerio_crawler.js
+++ b/src/cheerio_crawler.js
@@ -9,6 +9,7 @@ import { checkParamOrThrow } from 'apify-client/build/utils';
 import BasicCrawler from './basic_crawler';
 import { addTimeoutToPromise } from './utils';
 import { getApifyProxyUrl } from './actor';
+import { BASIC_CRAWLER_TIMEOUT_MULTIPLIER } from './constants';
 
 const DEFAULT_OPTIONS = {
     requestTimeoutSecs: 30,
@@ -258,7 +259,7 @@ class CheerioCrawler {
             maxRequestRetries,
             maxRequestsPerCrawl,
             handleRequestFunction: (...args) => this._handleRequestFunction(...args),
-            handleRequestTimeoutSecs: handlePageTimeoutSecs * 2,
+            handleRequestTimeoutSecs: handlePageTimeoutSecs * BASIC_CRAWLER_TIMEOUT_MULTIPLIER,
             handleFailedRequestFunction,
 
             // Autoscaled pool options.
@@ -404,6 +405,9 @@ class CheerioCrawler {
             strictSSL: !this.ignoreSslErrors,
             proxy: this._getProxyUrl(),
         };
+
+        if (/PATCH|POST|PUT/.test(request.method)) mandatoryRequestOptions.body = request.payload;
+
         return Object.assign({}, this.requestOptions, mandatoryRequestOptions);
     }
 

--- a/src/cheerio_crawler.js
+++ b/src/cheerio_crawler.js
@@ -258,6 +258,7 @@ class CheerioCrawler {
             maxRequestRetries,
             maxRequestsPerCrawl,
             handleRequestFunction: (...args) => this._handleRequestFunction(...args),
+            handleRequestTimeoutSecs: handlePageTimeoutSecs * 2,
             handleFailedRequestFunction,
 
             // Autoscaled pool options.

--- a/src/constants.js
+++ b/src/constants.js
@@ -113,3 +113,11 @@ export const USER_AGENT_LIST = [
  * @type {string}
  */
 export const APIFY_API_BASE_URL = 'https://api.apify.com/v2';
+
+/**
+ * Multiplier used in CheerioCrawler and PuppeteerCrawler to set a reasonable
+ * handleRequestTimeoutSecs in BasicCrawler that would not impare functionality.
+ *
+ * @type {number}
+ */
+export const BASIC_CRAWLER_TIMEOUT_MULTIPLIER = 10;

--- a/src/puppeteer.js
+++ b/src/puppeteer.js
@@ -206,7 +206,7 @@ export const launchPuppeteer = (options = {}) => {
     checkParamOrThrow(options.proxyUrl, 'options.proxyUrl', 'Maybe String');
     checkParamOrThrow(options.useApifyProxy, 'options.useApifyProxy', 'Maybe Boolean');
     checkParamOrThrow(options.liveView, 'options.liveView', 'Maybe Boolean');
-    checkParamOrThrow(options.liveViewOptions, 'options.liveViewOptoins', 'Maybe Object');
+    checkParamOrThrow(options.liveViewOptions, 'options.liveViewOptions', 'Maybe Object');
     if (options.useApifyProxy && options.proxyUrl) throw new Error('Cannot combine "options.useApifyProxy" with "options.proxyUrl"!');
 
     const puppeteer = getPuppeteerOrThrow();

--- a/src/puppeteer_pool.js
+++ b/src/puppeteer_pool.js
@@ -8,11 +8,11 @@ import LinkedList from 'apify-shared/linked_list';
 import rimraf from 'rimraf';
 import { checkParamOrThrow } from 'apify-client/build/utils';
 import { launchPuppeteer } from './puppeteer';
+import { addTimeoutToPromise } from './utils';
 
 /* global process */
 
 const PROCESS_KILL_TIMEOUT_MILLIS = 5000;
-const PAGE_CLOSE_KILL_TIMEOUT_MILLIS = 1000;
 
 const DEFAULT_OPTIONS = {
     reusePages: false,
@@ -21,9 +21,9 @@ const DEFAULT_OPTIONS = {
     maxOpenPagesPerInstance: 50,
     retireInstanceAfterRequestCount: 100,
 
-    // These can't be constants because we need it for unit tests.
-    instanceKillerIntervalMillis: 60 * 1000,
-    killInstanceAfterMillis: 5 * 60 * 1000,
+    puppeteerOperationTimeoutSecs: 15,
+    instanceKillerIntervalSecs: 60,
+    killInstanceAfterSecs: 300,
 
     // TODO: use settingsRotator()
     launchPuppeteerFunction: launchPuppeteerOptions => launchPuppeteer(launchPuppeteerOptions),
@@ -109,9 +109,13 @@ class PuppeteerInstance {
  *   Maximum number of requests that can be processed by a single browser instance.
  *   After the limit is reached, the browser is retired and new requests are
  *   handled by a new browser instance.
- * @param {Number} [options.instanceKillerIntervalMillis=60000]
+ * @param {Number} [options.puppeteerOperationTimeoutSecs=15]
+ *   All browser management operations such as launching a new browser, opening a new page
+ *   or closing a page will timeout after the set number of seconds and the connected
+ *   browser will be retired.
+ * @param {Number} [options.instanceKillerIntervalSecs=60]
  *   Indicates how often are the open Puppeteer instances checked whether they can be closed.
- * @param {Number} [options.killInstanceAfterMillis=300000]
+ * @param {Number} [options.killInstanceAfterSecs=300]
  *   When Puppeteer instance reaches the `options.retireInstanceAfterRequestCount` limit then
  *   it is considered retired and no more tabs will be opened. After the last tab is closed the
  *   whole browser is closed too. This parameter defines a time limit between the last tab was opened and
@@ -134,20 +138,15 @@ class PuppeteerInstance {
  */
 class PuppeteerPool {
     constructor(options = {}) {
-        checkParamOrThrow(options, 'options', 'Object');
-
-        // For backwards compatibility, in the future we can remove this...
-        if (!options.retireInstanceAfterRequestCount && options.abortInstanceAfterRequestCount) {
-            log.warning('PuppeteerPool: Parameter `abortInstanceAfterRequestCount` is deprecated! Use `retireInstanceAfterRequestCount` instead!');
-            options.retireInstanceAfterRequestCount = options.abortInstanceAfterRequestCount;
-        }
-
         const {
             maxOpenPagesPerInstance,
             retireInstanceAfterRequestCount,
             launchPuppeteerFunction,
+            puppeteerOperationTimeoutSecs,
             instanceKillerIntervalMillis,
+            instanceKillerIntervalSecs,
             killInstanceAfterMillis,
+            killInstanceAfterSecs,
             launchPuppeteerOptions,
             // recycleDiskCache,
             proxyUrls,
@@ -163,8 +162,17 @@ class PuppeteerPool {
         checkParamOrThrow(maxOpenPagesPerInstance, 'options.maxOpenPagesPerInstance', 'Number');
         checkParamOrThrow(retireInstanceAfterRequestCount, 'options.retireInstanceAfterRequestCount', 'Number');
         checkParamOrThrow(launchPuppeteerFunction, 'options.launchPuppeteerFunction', 'Function');
-        checkParamOrThrow(instanceKillerIntervalMillis, 'options.instanceKillerIntervalMillis', 'Number');
-        checkParamOrThrow(killInstanceAfterMillis, 'options.killInstanceAfterMillis', 'Number');
+        checkParamOrThrow(puppeteerOperationTimeoutSecs, 'options.puppeteerOperationTimeoutSecs', 'Number');
+        checkParamOrThrow(instanceKillerIntervalMillis, 'options.instanceKillerIntervalMillis', 'Maybe Number');
+        if (instanceKillerIntervalMillis) {
+            log.deprecated('PuppeteerPool: options.instanceKillerIntervalMillis is deprecated, use options.instanceKillerIntervalSecs instead.');
+        }
+        checkParamOrThrow(instanceKillerIntervalSecs, 'options.instanceKillerIntervalSecs', 'Number');
+        checkParamOrThrow(killInstanceAfterMillis, 'options.killInstanceAfterMillis', 'Maybe Number');
+        if (killInstanceAfterMillis) {
+            log.deprecated('PuppeteerPool: options.killInstanceAfterMillis is deprecated, use options.killInstanceAfterSecs instead.');
+        }
+        checkParamOrThrow(killInstanceAfterSecs, 'options.killInstanceAfterSecs', 'Number');
         checkParamOrThrow(launchPuppeteerOptions, 'options.launchPuppeteerOptions', 'Maybe Object');
         checkParamOrThrow(recycleDiskCache, 'options.recycleDiskCache', 'Maybe Boolean');
         checkParamOrThrow(proxyUrls, 'options.proxyUrls', 'Maybe Array');
@@ -184,7 +192,8 @@ class PuppeteerPool {
         this.reusePages = reusePages;
         this.maxOpenPagesPerInstance = maxOpenPagesPerInstance;
         this.retireInstanceAfterRequestCount = retireInstanceAfterRequestCount;
-        this.killInstanceAfterMillis = killInstanceAfterMillis;
+        this.puppeteerOperationTimeoutMillis = puppeteerOperationTimeoutSecs * 1000;
+        this.killInstanceAfterMillis = killInstanceAfterMillis || killInstanceAfterSecs * 1000;
         this.recycledDiskCacheDirs = recycleDiskCache ? new LinkedList() : null;
         this.proxyUrls = proxyUrls ? _.shuffle(proxyUrls) : null;
         this.launchPuppeteerFunction = async () => {
@@ -220,7 +229,10 @@ class PuppeteerPool {
         this.activeInstances = {};
         this.retiredInstances = {};
         this.lastUsedProxyUrlIndex = 0;
-        this.instanceKillerInterval = setInterval(() => this._killRetiredInstances(), instanceKillerIntervalMillis);
+        this.instanceKillerInterval = setInterval(
+            () => this._killRetiredInstances(),
+            instanceKillerIntervalMillis || instanceKillerIntervalSecs * 1000,
+        );
         this.idlePages = [];
         // WeakSet/Map items do not prevent garbage collection,
         // and thus no management of the collections is needed.
@@ -243,7 +255,11 @@ class PuppeteerPool {
         const id = this.browserCounter++;
         log.debug('PuppeteerPool: Launching new browser', { id });
 
-        const browserPromise = this.launchPuppeteerFunction();
+        const browserPromise = addTimeoutToPromise(
+            this.launchPuppeteerFunction(),
+            this.puppeteerOperationTimeoutMillis,
+            'PuppeteerPool: launchPuppeteerFunction timed out.',
+        );
         const instance = new PuppeteerInstance(id, browserPromise);
         this.activeInstances[id] = instance;
 
@@ -289,14 +305,8 @@ class PuppeteerPool {
             instance.activePages--;
 
             if (instance.activePages === 0 && this.retiredInstances[id]) {
-                // Run this with a delay, otherwise page.close() that initiated this 'targetdestroyed' event
-                // might fail with "Protocol error (Target.closeTarget): Target closed."
-                // TODO: Alternatively we could close here the first about:blank tab, which will cause
-                // the browser to be closed immediately without waiting
-                setTimeout(() => {
-                    log.debug('PuppeteerPool: Killing retired browser because it has no active pages', { id });
-                    this._killInstance(instance);
-                }, PAGE_CLOSE_KILL_TIMEOUT_MILLIS);
+                log.debug('PuppeteerPool: Killing retired browser because it has no active pages', { id });
+                this._killInstance(instance);
             }
         });
     }
@@ -383,10 +393,11 @@ class PuppeteerPool {
         try {
             const browser = await browserPromise;
             instance.killed = true;
-            await browser.close();
+            // Close the about:blank page to close the browser.
+            await (await browser.pages())[0].close();
             recycleDiskCache();
         } catch (err) {
-            log.exception(err, 'PuppeteerPool: Cannot close the browser instance', { id });
+            log.exception(err, 'PuppeteerPool: Cannot close the browser instance, it will be killed forcibly.', { id });
         }
     }
 
@@ -399,7 +410,7 @@ class PuppeteerPool {
         const allInstances = Object.values(this.activeInstances).concat(Object.values(this.retiredInstances));
         allInstances.forEach((instance) => {
             try {
-                instance.childProcess.kill('SIGINT');
+                instance.childProcess.kill('SIGKILL');
             } catch (e) {
                 // do nothing, it's dead
             }
@@ -449,7 +460,7 @@ class PuppeteerPool {
             }
         }
         // If there are no live pages to be reused, we spawn a new tab.
-        return this._openNewTab();
+        return this._openNewTab(2);
     }
 
     /**
@@ -457,10 +468,11 @@ class PuppeteerPool {
      * that resolves to an instance of a Puppeteer
      * <a href="https://pptr.dev/#?product=Puppeteer&show=api-class-page" target="_blank"><code>Page</code></a>.
      *
+     * @param {number} retryCount
      * @return {Promise<Page>}
      * @ignore
      */
-    async _openNewTab() {
+    async _openNewTab(retryCount) {
         let instance = Object
             .values(this.activeInstances)
             .find(inst => inst.activePages < this.maxOpenPagesPerInstance);
@@ -471,16 +483,28 @@ class PuppeteerPool {
 
         try {
             const browser = await instance.browserPromise;
-            const page = await browser.newPage();
+            const page = await addTimeoutToPromise(
+                browser.newPage(),
+                this.puppeteerOperationTimeoutMillis,
+                'PuppeteerPool: browser.newPage() timed out.',
+            );
             this._focusOldestTab(browser).catch(() => log.debug('Could not focus oldest tab.'));
             this.pagesToInstancesMap.set(page, instance);
             return this._decoratePage(page);
         } catch (err) {
-            log.exception(err, 'PuppeteerPool: Browser.newPage() failed', { id: instance.id });
             this._retireInstance(instance);
-
-            // !TODO: don't throw an error but repeat newPage with some delay
-            throw err;
+            if (retryCount) {
+                return new Promise((resolve) => {
+                    // We can do this because _retireInstance is synchronous
+                    // so the page will open in a different browser.
+                    setImmediate(() => {
+                        resolve(this._openNewTab(--retryCount));
+                    });
+                });
+            }
+            const betterError = new Error(`PuppeteerPool: browser.newPage() failed: ${instance.id}.`);
+            betterError.stack = err.stack;
+            throw betterError;
         }
     }
 
@@ -614,7 +638,15 @@ class PuppeteerPool {
             page.removeAllListeners();
             this.idlePages.push(page);
         } else {
-            await page.close();
+            try {
+                await addTimeoutToPromise(
+                    page.close(),
+                    this.puppeteerOperationTimeoutMillis,
+                    'PuppeteerPool: page.close() timed out.',
+                );
+            } catch (err) {
+                log.debug('PuppeteerPool: page.close() failed.', { reason: err && err.message });
+            }
         }
     }
 }

--- a/src/puppeteer_pool.js
+++ b/src/puppeteer_pool.js
@@ -13,6 +13,7 @@ import { addTimeoutToPromise } from './utils';
 /* global process */
 
 const PROCESS_KILL_TIMEOUT_MILLIS = 5000;
+const OPEN_NEW_TAB_RETRIES = 2;
 
 const DEFAULT_OPTIONS = {
     reusePages: false,
@@ -460,7 +461,7 @@ class PuppeteerPool {
             }
         }
         // If there are no live pages to be reused, we spawn a new tab.
-        return this._openNewTab(2);
+        return this._openNewTab(OPEN_NEW_TAB_RETRIES);
     }
 
     /**
@@ -497,9 +498,7 @@ class PuppeteerPool {
                 return new Promise((resolve) => {
                     // We can do this because _retireInstance is synchronous
                     // so the page will open in a different browser.
-                    setImmediate(() => {
-                        resolve(this._openNewTab(--retryCount));
-                    });
+                    resolve(this._openNewTab(--retryCount));
                 });
             }
             const betterError = new Error(`PuppeteerPool: browser.newPage() failed: ${instance.id}.`);

--- a/src/utils.js
+++ b/src/utils.js
@@ -335,19 +335,20 @@ export const getTypicalChromeExecutablePath = () => {
  * @ignore
  */
 export const addTimeoutToPromise = (promise, timeoutMillis, errorMessage) => {
-    return new Promise((resolve, reject) => {
+    return new Promise(async (resolve, reject) => {
         if (!isPromise(promise)) throw new Error('Parameter promise of type Promise must be provided.');
         checkParamOrThrow(timeoutMillis, 'timeoutMillis', 'Number');
         checkParamOrThrow(errorMessage, 'errorMessage', 'String');
 
         const timeout = setTimeout(() => reject(new Error(errorMessage)), timeoutMillis);
-        promise.then((data) => {
-            clearTimeout(timeout);
+        try {
+            const data = await promise;
             resolve(data);
-        }, (reason) => {
+        } catch (err) {
+            reject(err);
+        } finally {
             clearTimeout(timeout);
-            reject(reason);
-        });
+        }
     });
 };
 

--- a/test/actor.js
+++ b/test/actor.js
@@ -9,6 +9,8 @@ import { ApifyCallError } from '../build/errors';
 // NOTE: test use of require() here because this is how its done in acts
 const Apify = require('../build/index');
 
+const { utils: { log } } = Apify;
+
 /* global process, describe, it */
 
 // TODO: override console.log() to test the error messages (now they are printed to console)
@@ -1027,6 +1029,8 @@ describe('Apify.getApifyProxyUrl()', () => {
 
     // Test old params - session, groups
     it('should be backwards compatible', () => {
+        const ll = log.getLevel();
+        log.setLevel(log.LEVELS.ERROR);
         process.env[ENV_VARS.PROXY_PASSWORD] = 'abc123';
         process.env[ENV_VARS.PROXY_HOSTNAME] = 'my.host.com';
         process.env[ENV_VARS.PROXY_PORT] = 123;
@@ -1060,6 +1064,7 @@ describe('Apify.getApifyProxyUrl()', () => {
             hostname: 'your.host.com',
             port: 345,
         })).to.be.eql('http://auto:xyz@your.host.com:345');
+        log.setLevel(ll);
     });
 
     it('should throw on invalid proxy args', () => {

--- a/test/cheerio_crawler.js
+++ b/test/cheerio_crawler.js
@@ -155,6 +155,9 @@ describe('CheerioCrawler', () => {
                 handleFailedRequestFunction: ({ request }) => failed.push(request),
             });
 
+            // Override low value to prevent seeing timeouts from BasicCrawler
+            cheerioCrawler.basicCrawler.handleRequestTimeoutMillis = 10000;
+
             await requestList.initialize();
             await cheerioCrawler.run();
 

--- a/test/puppeteer_pool.js
+++ b/test/puppeteer_pool.js
@@ -557,19 +557,20 @@ describe('PuppeteerPool', () => {
     describe('prevents hanging of puppeteer operations', () => {
         let pool;
         beforeEach(() => {
+            log.setLevel(log.LEVELS.OFF);
             pool = new Apify.PuppeteerPool({
-                puppeteerOperationTimeoutSecs: 0.5,
+                puppeteerOperationTimeoutSecs: 0.05,
                 launchPuppeteerOptions: {
                     headless: true,
                 },
             });
         });
-        afterEach(() => pool.destroy());
+        afterEach(async () => {
+            log.setLevel(log.LEVELS.ERROR);
+            await pool.destroy();
+        });
 
         it('should work', async () => {
-            const page = await pool.newPage();
-            const browser = page.browser();
-            browser.newPage = () => shortSleep(2000);
             try {
                 await pool._openNewTab(0); // eslint-disable-line no-underscore-dangle
                 throw new Error('invalid error');

--- a/test/puppeteer_pool.js
+++ b/test/puppeteer_pool.js
@@ -536,7 +536,7 @@ describe('PuppeteerPool', () => {
                     await pool.newPage();
                     throw new Error('Invalid error.');
                 } catch (err) {
-                    expect(err.message).to.include('useApifyProxy');
+                    expect(err.stack).to.include('useApifyProxy');
                 }
             });
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -842,3 +842,39 @@ describe('utils.snakeCaseToCamelCase()', () => {
         });
     });
 });
+
+describe('utils.addTimeoutToPromise()', () => {
+    it('should timeout', async () => {
+        const clock = sinon.useFakeTimers();
+        try {
+            const p = utils.addTimeoutToPromise(
+                new Promise(r => setTimeout(r, 500)),
+                100,
+                'Timed out.',
+            );
+            clock.tick(101);
+            await p;
+            throw new Error('Wrong error.');
+        } catch (err) {
+            expect(err.message).to.be.eql('Timed out.');
+        } finally {
+            clock.restore();
+        }
+    });
+    it('should not timeout too soon', async () => {
+        const clock = sinon.useFakeTimers();
+        try {
+            const p = utils.addTimeoutToPromise(
+                new Promise(r => setTimeout(() => r('Done'), 100)),
+                500,
+                'Timed out.',
+            );
+            clock.tick(101);
+            expect(await p).to.be.eql('Done');
+        } catch (err) {
+            throw new Error('This should not fail.');
+        } finally {
+            clock.restore();
+        }
+    });
+});


### PR DESCRIPTION
This should resolve the trouble where a hanging `browser.newPage()` would hang request processing to the point where the actor would be left with 1 or 2 unprocessed requests and would never shut down.

   - adds a timeout to `BasicCrawler`
       - other Crawlers now set this timeout to 2x their timeouts
   - adds timeout to puppeteer invocations in `PuppeteerPool`
   - removes some deprecations and TODOs