### PR TITLE
Add no-undef rule to eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,7 +19,6 @@
     "no-plusplus": 0,
     "strict": ["error", "global"],
     "max-len": ["error", 150],
-    "no-undef": 0,
     "func-names": 0,
     "import/prefer-default-export": 0,
     "import/no-absolute-path": 0,

--- a/src/puppeteer_live_view_client.js
+++ b/src/puppeteer_live_view_client.js
@@ -3,6 +3,8 @@ import { checkParamOrThrow } from 'apify-client/build/utils';
 // Everything gets destroyed slowly to make the UX better
 const DESTROY_FADEOUT_MILLIS = 2000;
 
+/* global document, window */
+
 /**
  * Creates a page line in the Index.
  *

--- a/src/puppeteer_utils.js
+++ b/src/puppeteer_utils.js
@@ -29,6 +29,7 @@ const hideWebDriver = async (page) => {
     checkParamOrThrow(page, 'page', 'Object');
 
     await page.evaluateOnNewDocument(() => {
+        /* global Navigator, window */
         var modifiedNavigator; // eslint-disable-line no-var
         try {
             if (Navigator.prototype.hasOwnProperty('webdriver')) { // eslint-disable-line no-prototype-builtins

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,0 +1,11 @@
+{
+    "globals": {
+        "it": false,
+        "describe": false,
+        "xit": false,
+        "before": false,
+        "after": false,
+        "beforeEach": false,
+        "afterEach": false
+    }
+}

--- a/test/puppeteer_utils.js
+++ b/test/puppeteer_utils.js
@@ -4,7 +4,7 @@ import Apify from '../build/index';
 
 const { utils: { log } } = Apify;
 
-/* global describe, it */
+/* global window */
 
 describe('Apify.utils.puppeteer', () => {
     let ll;
@@ -76,6 +76,7 @@ describe('Apify.utils.puppeteer', () => {
 
             await Apify.utils.puppeteer.injectJQuery(page);
             const result2 = await page.evaluate(() => {
+                /* global $ */
                 return {
                     isDefined: window.jQuery === window.$,
                     text: $('h1').text(),
@@ -104,6 +105,7 @@ describe('Apify.utils.puppeteer', () => {
 
             await Apify.utils.puppeteer.injectUnderscore(page);
             const result2 = await page.evaluate(() => {
+                /* global _ */
                 return { isDefined: _.isEmpty({}) };
             });
             expect(result2).to.eql({ isDefined: true });


### PR DESCRIPTION
Implementing by adding a test-specific `.eslintrc.json` that defines all the mocha globals for test files only and then fixing manually all the other errors.