### PR TITLE
Feature/middlewares

### DIFF
--- a/src/puppeteer_crawler.js
+++ b/src/puppeteer_crawler.js
@@ -5,9 +5,10 @@ import BasicCrawler from './basic_crawler';
 import PuppeteerPool from './puppeteer_pool';
 import { addTimeoutToPromise } from './utils';
 import { BASIC_CRAWLER_TIMEOUT_MULTIPLIER } from './constants';
+import { gotoExtended } from './puppeteer_utils';
 
 const DEFAULT_OPTIONS = {
-    gotoFunction: async ({ request, page }) => page.goto(request.url, { timeout: 60000 }),
+    gotoFunction: async ({ request, page }) => gotoExtended(page, request, { timeout: 60000 }),
     handlePageTimeoutSecs: 60,
     handleFailedRequestFunction: ({ request }) => {
         const details = _.pick(request, 'id', 'url', 'method', 'uniqueKey');
@@ -276,6 +277,7 @@ class PuppeteerCrawler {
      */
     async _handleRequestFunction({ request, autoscaledPool }) {
         const page = await this.puppeteerPool.newPage();
+
         try {
             const response = await this.gotoFunction({ page, request, autoscaledPool, puppeteerPool: this.puppeteerPool });
             request.loadedUrl = page.url();

--- a/src/puppeteer_utils.js
+++ b/src/puppeteer_utils.js
@@ -9,6 +9,7 @@ import LruCache from 'apify-shared/lru_cache';
 import { RequestQueue, RequestQueueLocal } from './request_queue';
 import Request from './request';
 import { enqueueLinks } from './enqueue_links';
+import { addInterceptRequestHandler, removeInterceptRequestHandler } from './puppeteers_request_interception';
 
 const jqueryPath = require.resolve('jquery/dist/jquery.min');
 const underscorePath = require.resolve('underscore/underscore-min');
@@ -231,11 +232,10 @@ const enqueueRequestsFromClickableElements = async (page, selector, purls, reque
  * @memberOf puppeteer
  */
 const blockResources = async (page, resourceTypes = ['stylesheet', 'font', 'image', 'media']) => {
-    await page.setRequestInterception(true);
-    page.on('request', (request) => {
+    await addInterceptRequestHandler(page, async (request) => {
         const type = request.resourceType();
-        if (resourceTypes.includes(type)) request.abort();
-        else request.continue();
+        if (resourceTypes.includes(type)) await request.abort();
+        else await request.continue();
     });
 };
 
@@ -261,10 +261,7 @@ const cacheResponses = async (page, cache, responseUrlRules) => {
     // Check that rules are either String or RegExp
     responseUrlRules.forEach((rule, index) => checkParamOrThrow(rule, `responseUrlRules[${index}]`, 'String | RegExp'));
 
-    // Required to be able to intercept requests
-    await page.setRequestInterception(true);
-
-    page.on('request', async (request) => {
+    await addInterceptRequestHandler(page, async (request) => {
         const url = request.url();
 
         if (cache[url]) {
@@ -272,7 +269,7 @@ const cacheResponses = async (page, cache, responseUrlRules) => {
             return;
         }
 
-        request.continue();
+        await request.continue();
     });
 
     page.on('response', async (response) => {
@@ -348,6 +345,56 @@ const compileScript = (scriptString, context = Object.create(null)) => {
     return func;
 };
 
+/**
+ * Extended version of page.goto() allowing to perform requests with HTTP method other than GET,
+ * with custom headers and POST payload. URL, method, headers and payload are taken from
+ * request parameter that must be an instance of Apify.Request class.
+ *
+ * @param {Page} page
+ *   Puppeteer <a href="https://pptr.dev/#?product=Puppeteer&show=api-class-page" target="_blank"><code>Page</code></a> object.
+ * @param {Request} request {@link Request} object.
+ * @param {Object} gotoOptions Custom options for page.goto().
+ * @return {Promise<Response>}
+ *
+ * @memberOf puppeteer
+ */
+export const gotoExtended = async (page, request, gotoOptions = {}) => {
+    checkParamOrThrow(page, 'page', 'Object');
+    checkParamPrototypeOrThrow(request, 'request', Request, 'Apify.Request');
+    checkParamOrThrow(gotoOptions, 'gotoOptions', 'Object');
+
+    const { method, headers, payload } = request;
+
+    if (method !== 'GET' || payload || !_.isEmpty(headers)) {
+        const interceptRequestHandler = async (interceptedRequest) => {
+            if (method !== 'GET') interceptedRequest._method = method; // eslint-disable-line
+            if (payload) interceptedRequest._postData = payload; // eslint-disable-line
+            if (!_.isEmpty(headers)) interceptedRequest._headers = headers; // eslint-disable-line
+
+            await removeInterceptRequestHandler(page, interceptRequestHandler); // We wan't this to be called only for the initial request.
+            await interceptedRequest.continue();
+        };
+
+        await addInterceptRequestHandler(page, interceptRequestHandler);
+    }
+
+    return page.goto(request.url, gotoOptions);
+};
+
+/*
+export const enqueueClickables = async (page, purls, selector) => {
+    const interceptRequestHandler = async (interceptedRequest) => {
+        // TODO: configure everything here
+    };
+
+    await addInterceptRequestHandler(page, interceptRequestHandler);
+
+    // TODO: Click elements here
+
+    await removeInterceptRequestHandler(page, interceptRequestHandler);
+};
+*/
+
 let logEnqueueLinksDeprecationWarning = true;
 
 /**
@@ -387,4 +434,7 @@ export const puppeteerUtils = {
     blockResources,
     cacheResponses,
     compileScript,
+    gotoExtended,
+    addInterceptRequestHandler,
+    removeInterceptRequestHandler,
 };

--- a/src/puppeteer_utils.js
+++ b/src/puppeteer_utils.js
@@ -367,12 +367,14 @@ export const gotoExtended = async (page, request, gotoOptions = {}) => {
 
     if (method !== 'GET' || payload || !_.isEmpty(headers)) {
         const interceptRequestHandler = async (interceptedRequest) => {
-            if (method !== 'GET') interceptedRequest._method = method; // eslint-disable-line
-            if (payload) interceptedRequest._postData = payload; // eslint-disable-line
-            if (!_.isEmpty(headers)) interceptedRequest._headers = headers; // eslint-disable-line
+            const overrides = {};
 
+            if (method !== 'GET') overrides.method = method;
+            if (payload) overrides.postData = payload;
+            if (!_.isEmpty(headers)) overrides.headers = headers;
+
+            await interceptedRequest.continue(overrides);
             await removeInterceptRequestHandler(page, interceptRequestHandler); // We wan't this to be called only for the initial request.
-            await interceptedRequest.continue();
         };
 
         await addInterceptRequestHandler(page, interceptRequestHandler);

--- a/src/puppeteer_utils.js
+++ b/src/puppeteer_utils.js
@@ -366,7 +366,13 @@ export const gotoExtended = async (page, request, gotoOptions = {}) => {
     const { method, headers, payload } = request;
 
     if (method !== 'GET' || payload || !_.isEmpty(headers)) {
+        let wasCalled = false;
         const interceptRequestHandler = async (interceptedRequest) => {
+            // We want to ensure that this won't get executed again in a case that there is a subsequent request
+            // for example for some asset file link from main HTML.
+            if (wasCalled) return interceptedRequest.continue();
+
+            wasCalled = true;
             const overrides = {};
 
             if (method !== 'GET') overrides.method = method;

--- a/src/puppeteers_request_interception.js
+++ b/src/puppeteers_request_interception.js
@@ -1,0 +1,109 @@
+import _ from 'underscore';
+import { checkParamOrThrow } from 'apify-client/build/utils';
+
+// We use weak maps here so that the content gets discarted after page gets closed.
+const pageInterceptRequestHandlersMap = new WeakMap(); // Maps page to an array of request interception handlers.
+const pageInterceptRequestMasterHandlerMap = new WeakMap(); // Maps page to master request interception handler.
+
+/**
+ * Executes an array for given intercept request handlers for a given request object.
+ *
+ * @param {Request} request Puppeteer's Request object.
+ * @param {Array} interceptRequestHandlers An array of intercept request handlers.
+ * @ignore
+ */
+const handleRequest = (request, interceptRequestHandlers) => {
+    let wasAborted = false;
+    let wasResponded = false;
+    let wasContinued = false;
+
+    const originalContinue = request.continue.bind(request);
+    request.continue = () => {
+        wasContinued = true;
+    };
+
+    request.abort = _.wrap(request.abort.bind(request), (abort, ...args) => {
+        wasAborted = true;
+
+        return abort(...args);
+    });
+
+    request.respond = _.wrap(request.respond.bind(request), (respond, ...args) => {
+        wasResponded = false;
+
+        return respond(...args);
+    });
+
+    _.some(interceptRequestHandlers, (handler) => {
+        wasContinued = false;
+
+        handler(request);
+
+        // Check that one of the functions was called.
+        if (!wasAborted && !wasResponded && !wasContinued) {
+            throw new Error('Intercept request handler must call one of request.continue|respond|abort() methods!');
+        }
+
+        // If request was aborted or responded then we can finish immediately.
+        return wasAborted || wasResponded;
+    });
+
+    if (!wasAborted && !wasResponded) originalContinue();
+};
+
+/**
+ * Adds request interception handler in similar as `page.on('request', handler);` but in addition to that
+ * supports multiple parallel handlers.
+ *
+ * @param {Page} page
+ *   Puppeteer <a href="https://pptr.dev/#?product=Puppeteer&show=api-class-page" target="_blank"><code>Page</code></a> object.
+ * @param {Function} middleware Request interception handler. See @TODO for more information.
+ * @return {Promise<undefined>}
+ */
+export const addInterceptRequestHandler = async (page, handler) => {
+    checkParamOrThrow(page, 'page', 'Object');
+    checkParamOrThrow(handler, 'handler', 'Function');
+
+    // We haven't initiated an array of handlers yet.
+    if (!pageInterceptRequestHandlersMap.has(page)) {
+        pageInterceptRequestHandlersMap.set(page, []);
+    }
+
+    const handlersArray = pageInterceptRequestHandlersMap.get(page);
+    handlersArray.push(handler);
+
+    // First handler was just added at this point so we need to set up request interception.
+    if (handlersArray.length === 1) {
+        await page.setRequestInterception(true);
+
+        // This is a handler that get's set in page.on('request', ...) and that executes all the user
+        // added custom handlers.
+        const masterHandler = request => handleRequest(request, pageInterceptRequestHandlersMap.get(page));
+
+        pageInterceptRequestMasterHandlerMap.set(page, masterHandler);
+        page.on('request', masterHandler);
+    }
+};
+
+/**
+ * Removes request interception handler for given page.
+ *
+ * @param {Page} page
+ *   Puppeteer <a href="https://pptr.dev/#?product=Puppeteer&show=api-class-page" target="_blank"><code>Page</code></a> object.
+ * @param {Function} middleware Request interception handler. See @TODO for more information.
+ * @return {Promise<undefined>}
+ */
+export const removeInterceptRequestHandler = async (page, handler) => {
+    const handlersArray = pageInterceptRequestHandlersMap
+        .get(page)
+        .filter(item => item !== handler);
+
+    pageInterceptRequestHandlersMap.set(page, handlersArray);
+
+    // There are no more handlers so we can't turn off request interception and remove master handler.
+    if (handlersArray.length === 0) {
+        await page.setRequestInterception(false);
+        const requestHandler = pageInterceptRequestMasterHandlerMap.get(page);
+        page.removeListener('request', requestHandler);
+    }
+};

--- a/src/puppeteers_request_interception.js
+++ b/src/puppeteers_request_interception.js
@@ -57,7 +57,7 @@ const handleRequest = (request, interceptRequestHandlers) => {
  * Adds request interception handler in similar to `page.on('request', handler);` but in addition to that
  * supports multiple parallel handlers.
  *
- * All the handlers are executed in a serie as were added.
+ * All the handlers are executed sequentially in the order as they were added.
  * Each of the handlers must call one of `request.continue()`, `request.abort()` and `request.respond()`.
  * In addition to that any of the handlers may modify the request object by passing its overrides to `request.continue()`.
  * If multiple handlers modify same property then the last one wins.

--- a/test/puppeteer_utils.js
+++ b/test/puppeteer_utils.js
@@ -157,18 +157,16 @@ describe('Apify.utils.puppeteer', () => {
             const page = await browser.newPage();
             await Apify.utils.puppeteer.blockResources(page);
             page.on('response', response => loadedUrls.push(response.url()));
-            await page.setContent(`<html>
-                <body>
-                    <link rel="stylesheet" type="text/css" href="https://example.com/style.css">
-                    <img src="https://example.com/image.png" />
-                    <script src="https://example.com/script.js" defer="defer">></script>
-                </body>
-            </html>`, { waitUntil: 'networkidle0' });
+            await page.setContent(`<html><body>
+                <link rel="stylesheet" type="text/css" href="https://example.com/style.css">
+                <img src="https://example.com/image.png" />
+                <script src="https://example.com/script.js" defer="defer">></script>
+            </body></html>`, { waitUntil: 'networkidle0' });
         } finally {
             await browser.close();
         }
 
-        expect(loadedUrls).to.be.eql([
+        expect(loadedUrls).to.have.members([
             'https://example.com/script.js',
         ]);
     });
@@ -181,18 +179,16 @@ describe('Apify.utils.puppeteer', () => {
             const page = await browser.newPage();
             await Apify.utils.puppeteer.blockResources(page, ['script']);
             page.on('response', response => loadedUrls.push(response.url()));
-            await page.setContent(`<html>
-                <body>
-                    <link rel="stylesheet" type="text/css" href="https://example.com/style.css">
-                    <img src="https://example.com/image.png" />
-                    <script src="https://example.com/script.js" defer="defer">></script>
-                </body>
-            </html>`, { waitUntil: 'networkidle0' });
+            await page.setContent(`<html><body>
+                <link rel="stylesheet" type="text/css" href="https://example.com/style.css">
+                <img src="https://example.com/image.png" />
+                <script src="https://example.com/script.js" defer="defer">></script>
+            </body></html>`, { waitUntil: 'networkidle0' });
         } finally {
             await browser.close();
         }
 
-        expect(loadedUrls).to.be.eql([
+        expect(loadedUrls).to.have.members([
             'https://example.com/style.css',
             'https://example.com/image.png',
         ]);
@@ -278,6 +274,31 @@ describe('Apify.utils.puppeteer', () => {
             expect(content).to.be.eql('<html><head></head><body></body></html>');
         } finally {
             browser.close();
+        }
+    });
+
+    it('gotoExtended() works', async () => {
+        const browser = await Apify.launchPuppeteer({ headless: true });
+
+        try {
+            const page = await browser.newPage();
+            const request = new Apify.Request({
+                url: 'https://api.apify.com/v2/browser-info',
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json; charset=utf-8',
+                },
+                payload: '{ "foo": "bar" }',
+            });
+
+            const response = await Apify.utils.puppeteer.gotoExtended(page, request);
+
+            const { method, headers, bodyLength } = JSON.parse(await response.text());
+            expect(method).to.be.eql('POST');
+            expect(bodyLength).to.be.eql(16);
+            expect(headers['content-type']).to.be.eql('application/json; charset=utf-8');
+        } finally {
+            await browser.close();
         }
     });
 });

--- a/test/puppeteers_request_interception.js
+++ b/test/puppeteers_request_interception.js
@@ -1,0 +1,191 @@
+import { expect } from 'chai';
+import Apify from '../build/index';
+
+const { utils: { log } } = Apify;
+const { addInterceptRequestHandler, removeInterceptRequestHandler } = Apify.utils.puppeteer;
+
+// Simple page with image, script and stylesheet links.
+const HTML_PAGE = `<html><body>
+    <link rel="stylesheet" type="text/css" href="https://example.com/style.css">
+    <img src="https://example.com/image.png" />
+    <script src="https://example.com/script.js" defer="defer">></script>
+</body></html>`;
+
+describe('Apify.utils.puppeteer.addInterceptRequestHandler|removeInterceptRequestHandler()', () => {
+    it('should allow multiple handlers', async () => {
+        const browser = await Apify.launchPuppeteer({ headless: true });
+
+        const allUrls = [];
+        const loadedUrls = [];
+
+        try {
+            const page = await browser.newPage();
+
+            // Just collect all URLs.
+            await addInterceptRequestHandler(page, (request) => {
+                allUrls.push(request.url());
+                return request.continue();
+            });
+
+            // Abort images.
+            await addInterceptRequestHandler(page, (request) => {
+                if (request.resourceType() === 'image') return request.abort();
+                return request.continue();
+            });
+
+            // Abort scripts.
+            await addInterceptRequestHandler(page, (request) => {
+                if (request.resourceType() === 'script') return request.abort();
+                return request.continue();
+            });
+
+            // Save all loaded URLs.
+            page.on('response', response => loadedUrls.push(response.url()));
+
+            await page.setContent(HTML_PAGE, { waitUntil: 'networkidle0' });
+        } finally {
+            await browser.close();
+        }
+
+        expect(allUrls).to.have.members([
+            'https://example.com/script.js',
+            'https://example.com/style.css',
+            'https://example.com/image.png',
+        ]);
+
+        expect(loadedUrls).to.have.members([
+            'https://example.com/style.css',
+        ]);
+    });
+
+    it('should not propagate aborted/responded requests to following handlers', async () => {
+        const browser = await Apify.launchPuppeteer({ headless: true });
+        const propagatedUrls = [];
+
+        try {
+            const page = await browser.newPage();
+
+            // Abort images.
+            await addInterceptRequestHandler(page, (request) => {
+                if (request.resourceType() === 'image') return request.abort();
+                return request.continue();
+            });
+
+            // Respond scripts.
+            await addInterceptRequestHandler(page, (request) => {
+                if (request.resourceType() === 'script') {
+                    return request.respond({
+                        status: 404,
+                    });
+                }
+                return request.continue();
+            });
+
+            // Just collect all URLs propagated to the last handler.
+            await addInterceptRequestHandler(page, (request) => {
+                propagatedUrls.push(request.url());
+                return request.continue();
+            });
+            await page.setContent(HTML_PAGE, { waitUntil: 'networkidle0' });
+        } finally {
+            await browser.close();
+        }
+
+        expect(propagatedUrls).to.have.members([
+            'https://example.com/style.css',
+        ]);
+    });
+
+    it('should allow to modify request', async () => {
+        const browser = await Apify.launchPuppeteer({ headless: true });
+
+        try {
+            const page = await browser.newPage();
+
+            // Change all requests to DELETE.
+            await addInterceptRequestHandler(page, (request) => {
+                return request.continue({ method: 'DELETE' });
+            });
+            // Add some query parameters to request URLs.
+            await addInterceptRequestHandler(page, (request) => {
+                return request.continue({
+                    headers: {
+                        'Content-Type': 'application/json; charset=utf-8',
+                    },
+                    postData: '{ "foo": "bar" }',
+                });
+            });
+            // Change all requests to POST and add payload.
+            await addInterceptRequestHandler(page, (request) => {
+                return request.continue({
+                    method: 'POST',
+                });
+            });
+
+            // Check response that it's correct.
+            const response = await page.goto('https://api.apify.com/v2/browser-info', { waitUntil: 'networkidle0' });
+            const { method, headers, bodyLength } = JSON.parse(await response.text());
+            expect(method).to.be.eql('POST');
+            expect(bodyLength).to.be.eql(16);
+            expect(headers['content-type']).to.be.eql('application/json; charset=utf-8');
+        } finally {
+            await browser.close();
+        }
+    });
+});
+
+describe('Apify.utils.puppeteer.removeInterceptRequestHandler()', () => {
+    it('works', async () => {
+        const browser = await Apify.launchPuppeteer({ headless: true });
+
+        const loadedUrls = [];
+
+        try {
+            const page = await browser.newPage();
+            page.on('response', response => loadedUrls.push(response.url()));
+
+            // Abort images.
+            const abortImagesHandler = (request) => {
+                if (request.resourceType() === 'image') return request.abort();
+                return request.continue();
+            };
+            await addInterceptRequestHandler(page, abortImagesHandler);
+
+            // Abort scripts.
+            await addInterceptRequestHandler(page, (request) => {
+                if (request.resourceType() === 'script') return request.abort();
+                return request.continue();
+            });
+
+            // Load with scripts and images disabled.
+            await page.setContent('<html><body></body></html>');
+            await page.setContent(HTML_PAGE, { waitUntil: 'networkidle0' });
+            expect(loadedUrls).to.have.members([
+                'https://example.com/style.css',
+            ]);
+
+            // Try it once again.
+            await page.setContent('<html><body></body></html>');
+            await page.setContent(HTML_PAGE, { waitUntil: 'networkidle0' });
+            expect(loadedUrls).to.have.members([
+                'https://example.com/style.css',
+                'https://example.com/style.css',
+            ]);
+
+            // Enable images.
+            await removeInterceptRequestHandler(page, abortImagesHandler);
+
+            // Try to load once again if images appear there.
+            await page.setContent('<html><body></body></html>');
+            await page.setContent(HTML_PAGE, { waitUntil: 'networkidle0' });
+            expect(loadedUrls).to.have.members([
+                'https://example.com/style.css',
+                'https://example.com/style.css',
+                'https://example.com/style.css',
+                'https://example.com/image.png',
+            ]);
+        } finally {
+            await browser.close();
+        }
+    });
+});

--- a/test/puppeteers_request_interception.js
+++ b/test/puppeteers_request_interception.js
@@ -1,7 +1,6 @@
 import { expect } from 'chai';
 import Apify from '../build/index';
 
-const { utils: { log } } = Apify;
 const { addInterceptRequestHandler, removeInterceptRequestHandler } = Apify.utils.puppeteer;
 
 // Simple page with image, script and stylesheet links.


### PR DESCRIPTION
Summary:

* 2 new functions `Apify.utils.puppeteer.addInterceptRequestHandler()` and `Apify.utils.puppeteer.removeInterceptRequestHandler()` allowing to have multiple `page.on('request', ...)` handlers
* Functions for resource (css, image, ...) blocking and content caching migrated to this so that they can be used together
* Added `Apify.utils.puppeteer.gotoExtended()` that supports `Apify.Request` (all methods, headers, POST payload)
* Added some tests for resource blocking that were missing