### PR TITLE
Faster live view

### DIFF
--- a/src/crawlers/puppeteer_crawler.js
+++ b/src/crawlers/puppeteer_crawler.js
@@ -287,6 +287,7 @@ class PuppeteerCrawler {
 
         try {
             const response = await this.gotoFunction({ page, request, autoscaledPool, puppeteerPool: this.puppeteerPool });
+            await this.puppeteerPool.serveLiveViewSnapshot(page);
             request.loadedUrl = page.url();
             await addTimeoutToPromise(
                 this.handlePageFunction({ page, request, autoscaledPool, puppeteerPool: this.puppeteerPool, response }),

--- a/src/live_view/live_view_server.js
+++ b/src/live_view/live_view_server.js
@@ -164,13 +164,6 @@ class LiveViewServer {
     }
 
     /**
-     * @return {?Object}
-     */
-    getLastSnapshot() {
-        return this.lastSnapshot;
-    }
-
-    /**
      * @return {boolean}
      */
     isRunning() {

--- a/test/puppeteer_pool.js
+++ b/test/puppeteer_pool.js
@@ -596,6 +596,7 @@ describe('PuppeteerPool', () => {
 
             for (let i = 0; i < 3; i++) {
                 const page = await pool.newPage();
+                await pool.serveLiveViewSnapshot(page);
                 await pool.recyclePage(page);
             }
 

--- a/test/puppeteer_pool.js
+++ b/test/puppeteer_pool.js
@@ -550,7 +550,7 @@ describe('PuppeteerPool', () => {
         beforeEach(() => {
             log.setLevel(log.LEVELS.OFF);
             pool = new Apify.PuppeteerPool({
-                puppeteerOperationTimeoutSecs: 0.05,
+                puppeteerOperationTimeoutSecs: 0.005,
                 launchPuppeteerOptions: {
                     headless: true,
                 },
@@ -563,7 +563,7 @@ describe('PuppeteerPool', () => {
 
         it('should work', async () => {
             try {
-                await pool._openNewTab(0); // eslint-disable-line no-underscore-dangle
+                await pool._openNewTab(); // eslint-disable-line no-underscore-dangle
                 throw new Error('invalid error');
             } catch (err) {
                 expect(err.stack).to.include('timed out');


### PR DESCRIPTION
A user complained that it takes too long for live view to show first snapshot. This PR attempts to shorten the time to first snapshot by taking the snapshot right after navigation, instead of when the page is closing.

The snapshot is also being taken in parallel with `handlePageFunction` execution so by the time it finishes, it might already be done. If not, it is awaited before page close.