### PR TITLE
Removed duplicate Puppeteer launch log

### DIFF
--- a/src/puppeteer.js
+++ b/src/puppeteer.js
@@ -265,8 +265,10 @@ export const launchPuppeteer = async (options = {}) => {
 
     let browser;
     if (optsCopy.proxyUrl) {
+        // The log for launching with proxyUrl is inside launchPuppeteerWithProxy
         browser = await launchPuppeteerWithProxy(puppeteer, optsCopy);
     } else {
+        log.info('Launching Puppeteer', _.omit(optsCopy, LAUNCH_PUPPETEER_LOG_OMIT_OPTS));
         browser = await puppeteer.launch(optsCopy);
     }
 

--- a/src/puppeteer.js
+++ b/src/puppeteer.js
@@ -274,6 +274,6 @@ export const launchPuppeteer = async (options = {}) => {
     if (optsCopy.stealth) {
         browser = applyStealthToBrowser(browser, optsCopy.stealthOptions);
     }
-    log.info('Launching Puppeteer', _.omit(optsCopy, LAUNCH_PUPPETEER_LOG_OMIT_OPTS));
+    
     return browser;
 };


### PR DESCRIPTION
This second log is almost the same but doesn't have the whole proxy URL. I don't know where you want the log to be.

Compare 
```
2019-09-25T11:46:43.190Z INFO: Launching Puppeteer {"args":["--no-sandbox","--user-agent=Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:64.0) Gecko/20100101 Firefox/64.0 s=0.8617189793878433"],"headless":true,"defaultViewport":{"width":1366,"height":768},"pipe":true,"proxyUrl":"http://session-0.8617189793878433:<redacted>@172.31.62.80:8011/"}
2019-09-25T11:46:43.454Z INFO: Launching Puppeteer {"args":["--no-sandbox","--user-agent=Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:64.0) Gecko/20100101 Firefox/64.0 s=0.8617189793878433","--proxy-server=http://127.0.0.1:32482"],"headless":true,"defaultViewport":{"width":1366,"height":768},"pipe":true}
```