### PR TITLE
fix infinite scroll

### DIFF
--- a/src/puppeteer_utils.js
+++ b/src/puppeteer_utils.js
@@ -494,10 +494,10 @@ export const infiniteScroll = async (page, options = {}) => {
 
     const doScroll = async () => {
         /* istanbul ignore next */
-        await page.evaluate(async () => {
-            const delta = document.body.scrollHeight === 0 ? SCROLL_HEIGHT_IF_ZERO : document.body.scrollHeight;
+        await page.evaluate(async (scrollHeightIfZero) => {
+            const delta = document.body.scrollHeight === 0 ? scrollHeightIfZero : document.body.scrollHeight;
             window.scrollBy(0, delta);
-        });
+        }, SCROLL_HEIGHT_IF_ZERO);
     };
 
     while (!finished) {


### PR DESCRIPTION
Constant was not propagated into page.evaluate. It crashed only on specific sites (youtube.com) therefore tests didn't cover it