### PR TITLE
[AP-1523] Fixed most deprecated docs links.

### DIFF
--- a/docs/api/Apify.md
+++ b/docs/api/Apify.md
@@ -36,7 +36,7 @@ separate, detailed, documentation pages accessible from the left sidebar.
 ## `Apify.addWebhook(options)` ⇒ `Promise<Object>`
 
 Creates an ad-hoc webhook for the current actor run, which lets you receive a notification when the actor run finished or failed. For more information
-about Apify actor webhooks, please see the <a href="https://apify.com/docs/webhooks" target="_blank">documentation</a>.
+about Apify actor webhooks, please see the <a href="https://docs.apify.com/webhooks" target="_blank">documentation</a>.
 
 Note that webhooks are only supported for actors running on the Apify platform. In local environment, the function will print a warning and have no
 effect.
@@ -60,7 +60,7 @@ effect.
 </tr>
 <tr>
 <td colspan="3"><p>Array of event types, which you can set for actor run, see
-  the <a href="https://apify.com/docs/webhooks#events-actor-run" target="_blank">actor run events</a> in the Apify doc.</p>
+  the <a href="https://docs.apify.com/webhooks#events-actor-run" target="_blank">actor run events</a> in the Apify doc.</p>
 </td></tr><tr>
 <td><code>options.requestUrl</code></td><td><code>string</code></td>
 </tr>
@@ -73,9 +73,9 @@ effect.
 <td colspan="3"><p>Payload template is a JSON-like string that describes the structure of the webhook POST request payload.
   It uses JSON syntax, extended with a double curly braces syntax for injecting variables <code>{{variable}}</code>.
   Those variables are resolved at the time of the webhook&#39;s dispatch, and a list of available variables with their descriptions
-  is available in the <a href="https://apify.com/docs/webhooks" target="_blank">Apify webhook documentation</a>.</p>
+  is available in the <a href="https://docs.apify.com/webhooks" target="_blank">Apify webhook documentation</a>.</p>
 <p>  When omitted, the default payload template will be used.
-  <a href="https://apify.com/docs/webhooks" target="_blank">See the docs for the default payload template</a>.</p>
+  <a href="https://docs.apify.com/webhooks" target="_blank">See the docs for the default payload template</a>.</p>
 </td></tr><tr>
 <td><code>[options.idempotencyKey]</code></td><td><code>string</code></td>
 </tr>
@@ -101,7 +101,7 @@ actor run fails, the function throws the [`ApifyCallError`](../typedefs/apifycal
 
 If you want to run an actor task rather than an actor, please use the [`Apify.callTask()`](../api/apify#module_Apify.callTask) function instead.
 
-For more information about actors, read the <a href="https://apify.com/docs/actor" target="_blank">documentation</a>.
+For more information about actors, read the <a href="https://docs.apify.com/actor" target="_blank">documentation</a>.
 
 **Example usage:**
 
@@ -197,7 +197,7 @@ actor</a> and several other API endpoints to obtain the output.
 <tr>
 <td colspan="3"><p>Specifies optional webhooks associated with the actor run, which can be used
  to receive a notification e.g. when the actor finished or failed, see
- <a href="https://apify.com/docs/webhooks#adhoc">ad hook webhooks documentation</a> for detailed description.</p>
+ <a href="https://docs.apify.com/webhooks#adhoc">ad hook webhooks documentation</a> for detailed description.</p>
 </td></tr></tbody>
 </table>
 <a name="module_Apify.callTask"></a>
@@ -216,7 +216,7 @@ actor run failed, the function fails with [`ApifyCallError`](../typedefs/apifyca
 Note that an actor task is a saved input configuration and options for an actor. If you want to run an actor directly rather than an actor task,
 please use the [`Apify.call()`](../api/apify#module_Apify.call) function instead.
 
-For more information about actor tasks, read the [`documentation`](https://apify.com/docs/tasks).
+For more information about actor tasks, read the [`documentation`](https://docs.apify.com/tasks).
 
 **Example usage:**
 
@@ -303,20 +303,20 @@ obtain the output.
 <tr>
 <td colspan="3"><p>Specifies optional webhooks associated with the actor run, which can be used
  to receive a notification e.g. when the actor finished or failed, see
- <a href="https://apify.com/docs/webhooks#adhoc">ad hook webhooks documentation</a> for detailed description.</p>
+ <a href="https://docs.apify.com/webhooks#adhoc">ad hook webhooks documentation</a> for detailed description.</p>
 </td></tr></tbody>
 </table>
 <a name="module_Apify.client"></a>
 
 ## `Apify.client`
 
-Gets the default instance of the `ApifyClient` class provided <a href="https://apify.com/docs/sdk/apify-client-js/latest"
+Gets the default instance of the `ApifyClient` class provided <a href="https://sdk.apify.com"
 target="_blank">apify-client</a> by the NPM package. The instance is created automatically by the Apify SDK and it is configured using the
 `APIFY_API_BASE_URL`, `APIFY_USER_ID` and `APIFY_TOKEN` environment variables.
 
 The instance is used for all underlying calls to the Apify API in functions such as [`Apify.getValue()`](#module_Apify.getValue) or
 [`Apify.call()`](#module_Apify.call). The settings of the client can be globally altered by calling the
-<a href="https://apify.com/docs/sdk/apify-client-js/latest#ApifyClient-setOptions"
+<a href="https://sdk.apify.com#ApifyClient-setOptions"
 target="_blank">`Apify.client.setOptions()`</a> function. Beware that altering these settings might have unintended effects on the entire Apify SDK
 package.
 
@@ -394,7 +394,7 @@ Constructs an Apify Proxy URL using the specified settings. The proxy URL can be
 applications.
 
 For more information, see the <a href="https://my.apify.com/proxy" target="_blank">Apify Proxy</a> page in the app or the
-<a href="https://apify.com/docs/proxy" target="_blank">documentation</a>.
+<a href="https://docs.apify.com/proxy" target="_blank">documentation</a>.
 
 **Returns**: `String` - Returns the proxy URL, e.g. `http://auto:my_password@proxy.apify.com:8000`.
 
@@ -484,7 +484,7 @@ Returns a new object which contains information parsed from all the `APIFY_XXX` 
 }
 ```
 
-For the list of the `APIFY_XXX` environment variables, see <a href="https://apify.com/docs/actor#run-env-vars" target="_blank">Actor
+For the list of the `APIFY_XXX` environment variables, see <a href="https://docs.apify.com/actor#run-env-vars" target="_blank">Actor
 documentation</a>. If some of the variables are not defined or are invalid, the corresponding value in the resulting object will be null.
 
 <a name="module_Apify.getInput"></a>
@@ -611,7 +611,7 @@ The `launchPuppeteer()` function alters the following Puppeteer options:
    </li>
    <li>
        If <code>options.useApifyProxy</code> is <code>true</code> then the function generates a URL of
-       <a href="https://apify.com/docs/proxy" target="_blank">Apify Proxy</a>
+       <a href="https://docs.apify.com/proxy" target="_blank">Apify Proxy</a>
        based on <code>options.apifyProxyGroups</code> and <code>options.apifyProxySession</code> and passes it as <code>options.proxyUrl</code>.
    </li>
    <li>
@@ -628,7 +628,7 @@ The `launchPuppeteer()` function alters the following Puppeteer options:
 
 To use this function, you need to have the <a href="https://www.npmjs.com/package/puppeteer" target="_blank">puppeteer</a> NPM package installed in
 your project. When running on the Apify cloud, you can achieve that simply by using the `apify/actor-node-chrome` base Docker image for your actor -
-see <a href="https://apify.com/docs/actor#base-images" target="_blank">Apify Actor documentation</a> for details.
+see <a href="https://docs.apify.com/actor#base-images" target="_blank">Apify Actor documentation</a> for details.
 
 For an example of usage, see the [Synchronous run Example](../examples/synchronousrun) or the
 [Puppeteer proxy Example](../examples/puppeteerwithproxy)

--- a/docs/api/CheerioCrawler.md
+++ b/docs/api/CheerioCrawler.md
@@ -196,13 +196,13 @@ The exceptions are logged to the request using the
 <tr>
 <td colspan="3"><p>If set to <code>true</code>, <code>CheerioCrawler</code> will be configured to use
   <a href="https://my.apify.com/proxy" target="_blank">Apify Proxy</a> for all connections.
-  For more information, see the <a href="https://apify.com/docs/proxy" target="_blank">documentation</a></p>
+  For more information, see the <a href="https://docs.apify.com/proxy" target="_blank">documentation</a></p>
 </td></tr><tr>
 <td><code>[options.apifyProxyGroups]</code></td><td><code>Array<String></code></td><td></td>
 </tr>
 <tr>
 <td colspan="3"><p>An array of proxy groups to be used
-  by the <a href="https://apify.com/docs/proxy" target="_blank">Apify Proxy</a>.
+  by the <a href="https://docs.apify.com/proxy" target="_blank">Apify Proxy</a>.
   Only applied if the <code>useApifyProxy</code> option is <code>true</code>.</p>
 </td></tr><tr>
 <td><code>[options.apifyProxySession]</code></td><td><code>String</code></td><td></td>

--- a/docs/api/Dataset.md
+++ b/docs/api/Dataset.md
@@ -25,7 +25,7 @@ Note that `{DATASET_ID}` is the name or ID of the dataset. The default dataset h
 item in the dataset.
 
 If the `APIFY_TOKEN` environment variable is set but `APIFY_LOCAL_STORAGE_DIR` not, the data is stored in the
-<a href="https://apify.com/docs/storage#dataset" target="_blank">Apify Dataset</a> cloud storage. Note that you can force usage of the cloud storage
+<a href="https://docs.apify.com/storage#dataset" target="_blank">Apify Dataset</a> cloud storage. Note that you can force usage of the cloud storage
 also by passing the `forceCloud` option to [`Apify.openDataset()`](apify#module_Apify.openDataset) function, even if the `APIFY_LOCAL_STORAGE_DIR`
 variable is set.
 

--- a/docs/api/KeyValueStore.md
+++ b/docs/api/KeyValueStore.md
@@ -32,7 +32,7 @@ Note that `{STORE_ID}` is the name or ID of the key-value store. The default key
 data value.
 
 If the `APIFY_TOKEN` environment variable is set but `APIFY_LOCAL_STORAGE_DIR` not, the data is stored in the
-<a href="https://apify.com/docs/storage#key-value-store" target="_blank">Apify Key-value store</a> cloud storage. Note that you can force usage of the
+<a href="https://docs.apify.com/storage#key-value-store" target="_blank">Apify Key-value store</a> cloud storage. Note that you can force usage of the
 cloud storage also by passing the `forceCloud` option to [`Apify.openKeyValueStore()`](apify#module_Apify.openKeyValueStore) function, even if the
 `APIFY_LOCAL_STORAGE_DIR` variable is set.
 

--- a/docs/api/RequestQueue.md
+++ b/docs/api/RequestQueue.md
@@ -33,7 +33,7 @@ Note that `{QUEUE_ID}` is the name or ID of the request queue. The default queue
 `handled` or `pending`, and `{NUMBER}` is an integer indicating the position of the request in the queue.
 
 If the `APIFY_TOKEN` environment variable is set but `APIFY_LOCAL_STORAGE_DIR` not, the data is stored in the
-<a href="https://apify.com/docs/storage#queue" target="_blank">Apify Request Queue</a> cloud storage. Note that you can force usage of the cloud
+<a href="https://docs.apify.com/storage#queue" target="_blank">Apify Request Queue</a> cloud storage. Note that you can force usage of the cloud
 storage also by passing the `forceCloud` option to [`Apify.openRequestQueue()`](apify#module_Apify.openRequestQueue) function, even if the
 `APIFY_LOCAL_STORAGE_DIR` variable is set.
 

--- a/docs/examples/PuppeteerWithProxy.md
+++ b/docs/examples/PuppeteerWithProxy.md
@@ -3,7 +3,7 @@ id: puppeteerwithproxy
 title: Puppeteer With Proxy
 ---
 
-This example demonstrates how to load pages in headless Chrome / Puppeteer over <a href="https://apify.com/docs/proxy" target="_blank">Apify
+This example demonstrates how to load pages in headless Chrome / Puppeteer over <a href="https://docs.apify.com/proxy" target="_blank">Apify
 Proxy</a>. To make it work, you'll need an Apify Account that has access to the proxy. The proxy password is available on the
 <a href="https://my.apify.com/proxy" target="_blank">Proxy</a> page in the app. Just set it to the `APIFY_PROXY_PASSWORD`
 [environment variable](../guides/environmentvariables) or run the script using the CLI.

--- a/docs/examples/Screenshots.md
+++ b/docs/examples/Screenshots.md
@@ -16,7 +16,7 @@ In local configuration, the input is stored in the default key-value store's dir
 
 On the Apify cloud, the input can be either set manually in the UI app or passed as the POST payload to the
 <a href="https://apify.com/docs/api/v2#/reference/actors/run-collection/run-actor" target="_blank">Run actor API call</a>. For more details, see
-<a href="https://apify.com/docs/actor#input-output" target="_blank">Input and output</a> in the Apify Actor documentation.
+<a href="https://docs.apify.com/actor#input-output" target="_blank">Input and output</a> in the Apify Actor documentation.
 
 To run this example on the Apify Platform, select the `Node.js 10 + Chrome on Debian (apify/actor-node-chrome)` base image on the source tab of your
 actor configuration.

--- a/docs/guides/data_storage.md
+++ b/docs/guides/data_storage.md
@@ -14,7 +14,7 @@ code changes are needed.
 
 **Related links**
 
--   <a href="https://apify.com/docs/storage" target="_blank">Apify cloud storage documentation</a>
+-   <a href="https://docs.apify.com/storage" target="_blank">Apify cloud storage documentation</a>
 -   <a href="https://my.apify.com/storage" target="_blank">View storage in Apify app</a>
 -   <a href="https://apify.com/docs/api/v2#/reference/key-value-stores" target="_blank">API reference</a>
 

--- a/docs/guides/environment_variables.md
+++ b/docs/guides/environment_variables.md
@@ -36,7 +36,7 @@ The following table shows the basic environment variables used by Apify SDK:
           <tr>
             <td><code>APIFY_PROXY_PASSWORD</code></td>
             <td>
-              Optional password to <a href="https://apify.com/docs/proxy" target="_blank">Apify Proxy</a> for IP address rotation.
+              Optional password to <a href="https://docs.apify.com/proxy" target="_blank">Apify Proxy</a> for IP address rotation.
               If you have have an Apify Account, you can find the password on the
               <a href="https://my.apify.com/proxy" target="_blank">Proxy page</a> in the Apify app.
               This feature is optional. You can use your own proxies or no proxies at all.

--- a/docs/guides/getting_started.md
+++ b/docs/guides/getting_started.md
@@ -119,7 +119,7 @@ the running actor. Feel free to check out the other **Run** tabs, such as **Info
 **Key-value-store**, where the actor's **INPUT** and **OUTPUT** are stored.
 
 Good job. You're now ready to run your own source code on the Apify Platform. For more information visit the
-<a href="https://apify.com/docs/actor" target="_blank">Actor documentation page</a>, where you'll find everything about the platform's various
+<a href="https://docs.apify.com/actor" target="_blank">Actor documentation page</a>, where you'll find everything about the platform's various
 options.
 
 ## First crawler

--- a/docs/guides/getting_started_quick.md
+++ b/docs/guides/getting_started_quick.md
@@ -94,7 +94,7 @@ apify push
 ```
 
 Your script will be uploaded to the Apify Cloud and built there so that it can be run. For more information, view the
-<a href="https://apify.com/docs/cli" target="_blank">Apify CLI</a> and <a href="https://apify.com/docs/actor" target="_blank">Apify Actor</a>
+<a href="https://docs.apify.com/cli" target="_blank">Apify CLI</a> and <a href="https://docs.apify.com/actor" target="_blank">Apify Actor</a>
 documentation.
 
 ## Usage on the Apify Cloud
@@ -103,4 +103,4 @@ You can also develop your web scraping project in an online code editor directly
 You'll need to have an Apify Account. Go to <a href="https://my.apify.com/actors" target="_blank">Actors</a>, page in the app, click <i>Create new</i>
 and then go to the <i>Source</i> tab and start writing your code or paste one of the examples from the Examples section.
 
-For more information, view the <a href="https://apify.com/docs/actor#quick-start" target="_blank">Apify actors quick start guide</a>.
+For more information, view the <a href="https://docs.apify.com/actor#quick-start" target="_blank">Apify actors quick start guide</a>.

--- a/docs/guides/what_is_an_actor.md
+++ b/docs/guides/what_is_an_actor.md
@@ -15,6 +15,6 @@ store and somebody uses it, it runs under their account, not yours.
 **Related links**
 
 -   <a href="https://apify.com/store" target="_blank">Store of existing actors</a>
--   <a href="https://apify.com/docs/actor" target="_blank">Documentation</a>
+-   <a href="https://docs.apify.com/actor" target="_blank">Documentation</a>
 -   <a href="https://my.apify.com/actors" target="_blank">View actors in Apify app</a>
 -   <a href="https://apify.com/docs/api/v2#/reference/actors" target="_blank">API reference</a>

--- a/docs/readme/introduction.md
+++ b/docs/readme/introduction.md
@@ -11,7 +11,7 @@ to maintain queues of URLs to crawl, store crawling results to a local filesyste
 rotate proxies and much more.
 The SDK is available as the <a href="https://www.npmjs.com/package/apify" target="_blank"><code>apify</code></a> NPM package.
 It can be used either stand-alone in your own applications
-or in <a href="https://apify.com/docs/actor" target="_blank">actors</a>
+or in <a href="https://docs.apify.com/actor" target="_blank">actors</a>
 running on the <a href="https://apify.com/" target="_blank">Apify Cloud</a>.
 
 **View full documentation, guides and examples on the dedicated <a href="https://sdk.apify.com" target="_blank">Apify SDK project website</a>**

--- a/docs/typedefs/ActorRun.md
+++ b/docs/typedefs/ActorRun.md
@@ -8,7 +8,7 @@ title: ActorRun
 Represents information about an actor run, as returned by the [`Apify.call()`](../api/apify#module_Apify.call) or
 [`Apify.callTask()`](../api/apify#module_Apify.callTask) function. The object is almost equivalent to the JSON response of the
 <a href="https://apify.com/docs/api/v2#/reference/actors/run-collection/run-actor" target="_blank">Actor run</a> Apify API endpoint and extended with
-certain fields. For more details, see <a href="https://apify.com/docs/actor#run" target="_blank">Runs.</a>
+certain fields. For more details, see <a href="https://docs.apify.com/actor#run" target="_blank">Runs.</a>
 
 **Properties**
 
@@ -44,7 +44,7 @@ certain fields. For more details, see <a href="https://apify.com/docs/actor#run"
 </tr>
 <tr>
 <td colspan="3"><p>Status of the run. For possible values, see
-  <a href="https://apify.com/docs/actor#run-lifecycle" target="_blank">Run lifecycle</a>
+  <a href="https://docs.apify.com/actor#run-lifecycle" target="_blank">Run lifecycle</a>
   in Apify actor documentation.</p>
 </td></tr><tr>
 <td><code>meta</code></td><td><code>Object</code></td>
@@ -80,7 +80,7 @@ certain fields. For more details, see <a href="https://apify.com/docs/actor#run"
 </tr>
 <tr>
 <td colspan="3"><p>ID of the actor build used for the run. For details, see
-  <a href="https://apify.com/docs/actor#build" target="_blank">Builds</a>
+  <a href="https://docs.apify.com/actor#build" target="_blank">Builds</a>
   in Apify actor documentation.</p>
 </td></tr><tr>
 <td><code>buildNumber</code></td><td><code>String</code></td>
@@ -113,7 +113,7 @@ certain fields. For more details, see <a href="https://apify.com/docs/actor#run"
 <tr>
 <td colspan="3"><p>URL on which the web server running inside actor run&#39;s Docker container can be accessed.
   For more details, see
-  <a href="https://apify.com/docs/actor#container-web-server" target="_blank">Container web server</a>
+  <a href="https://docs.apify.com/actor#container-web-server" target="_blank">Container web server</a>
   in Apify actor documentation.</p>
 </td></tr><tr>
 <td><code>output</code></td><td><code>Object</code></td>

--- a/docs/typedefs/LaunchPuppeteerOptions.md
+++ b/docs/typedefs/LaunchPuppeteerOptions.md
@@ -55,13 +55,13 @@ Apify extends the launch options of Puppeteer. You can use any of the
 <tr>
 <td colspan="3"><p>If set to <code>true</code>, Puppeteer will be configured to use
   <a href="https://my.apify.com/proxy" target="_blank">Apify Proxy</a> for all connections.
-  For more information, see the <a href="https://apify.com/docs/proxy" target="_blank">documentation</a></p>
+  For more information, see the <a href="https://docs.apify.com/proxy" target="_blank">documentation</a></p>
 </td></tr><tr>
 <td><code>[apifyProxyGroups]</code></td><td><code>Array<String></code></td><td></td>
 </tr>
 <tr>
 <td colspan="3"><p>An array of proxy groups to be used
-  by the <a href="https://apify.com/docs/proxy" target="_blank">Apify Proxy</a>.
+  by the <a href="https://docs.apify.com/proxy" target="_blank">Apify Proxy</a>.
   Only applied if the <code>useApifyProxy</code> option is <code>true</code>.</p>
 </td></tr><tr>
 <td><code>[apifyProxySession]</code></td><td><code>String</code></td><td></td>


### PR DESCRIPTION
Fixed the following deprecated links with `sed`:
https://apify.com/docs/scraping
https://apify.com/docs/actor
https://apify.com/docs/tasks
https://apify.com/docs/storage
https://apify.com/docs/proxy
https://apify.com/docs/webhooks
https://apify.com/docs/cli
https://apify.com/docs/sdk/apify-client-js/latest

Checked output with `grep`.