### PR TITLE
[docs] Updated Dataset.getData() JSDoc to include the `count` property

### DIFF
--- a/docs/api/Dataset.md
+++ b/docs/api/Dataset.md
@@ -97,8 +97,9 @@ Returns items in the dataset based on the provided parameters. The returned obje
 {
     items, // Array|String|Buffer based on chosen format parameter.
     total, // Number
-    limit, // Number
     offset, // Number
+    count, // Number
+    limit, // Number
 }
 ```
 

--- a/src/dataset.js
+++ b/src/dataset.js
@@ -208,8 +208,9 @@ export class Dataset {
      * {
      *     items, // Array|String|Buffer based on chosen format parameter.
      *     total, // Number
-     *     limit, // Number
      *     offset, // Number
+     *     count, // Number
+     *     limit, // Number
      * }
      * ```
      *


### PR DESCRIPTION
Dataset.getData() return value was not documented properly.