### PR TITLE
fix parameter type on utils.puppeteer.blockRequests

### DIFF
--- a/docs/api/puppeteer.md
+++ b/docs/api/puppeteer.md
@@ -545,7 +545,7 @@ await page.goto('https://cnn.com');
   and end of the pattern. This limitation is enforced by the DevTools protocol.
   <code>.png</code> is the same as <code>*.png*</code>.</p>
 </td></tr><tr>
-<td><code>[options.extraUrlPatterns]</code></td><td><code>Array</code></td>
+<td><code>[options.extraUrlPatterns]</code></td><td><code>Array<string></code></td>
 </tr>
 <tr>
 <td colspan="3"><p>If you just want to append to the default blocked patterns, use this property.</p>

--- a/docs/api/puppeteer.md
+++ b/docs/api/puppeteer.md
@@ -545,7 +545,7 @@ await page.goto('https://cnn.com');
   and end of the pattern. This limitation is enforced by the DevTools protocol.
   <code>.png</code> is the same as <code>*.png*</code>.</p>
 </td></tr><tr>
-<td><code>[options.extraUrlPatterns]</code></td><td><code>boolean</code></td>
+<td><code>[options.extraUrlPatterns]</code></td><td><code>Array</code></td>
 </tr>
 <tr>
 <td colspan="3"><p>If you just want to append to the default blocked patterns, use this property.</p>

--- a/src/puppeteer_utils.js
+++ b/src/puppeteer_utils.js
@@ -235,7 +235,7 @@ const enqueueRequestsFromClickableElements = async (page, selector, purls, reque
  *   Only `*` can be used as a wildcard. It is also automatically added to the beginning
  *   and end of the pattern. This limitation is enforced by the DevTools protocol.
  *   `.png` is the same as `*.png*`.
- * @param {boolean} [options.extraUrlPatterns]
+ * @param {string[]} [options.extraUrlPatterns]
  *   If you just want to append to the default blocked patterns, use this property.
  * @return {Promise}
  * @memberOf puppeteer


### PR DESCRIPTION
Providing a `boolean` crashes on runtime