### PR TITLE
Add puppeteer util to block ads, trackers, and annoyances

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "dependencies": {
         "@apify/http-request": "^1.1.5",
         "@apify/ps-tree": "^1.1.3",
+        "@cliqz/adblocker-puppeteer": "^1.9.0",
         "@types/cheerio": "^0.22.15",
         "@types/node": "^13.1.8",
         "@types/puppeteer": "^2.0.0",
@@ -61,6 +62,7 @@
         "apify-shared": "^0.1.66",
         "cheerio": "^1.0.0-rc.3",
         "content-type": "^1.0.4",
+        "cross-fetch": "^3.0.4",
         "express": "^4.17.1",
         "fs-extra": "^8.1.0",
         "htmlparser2": "^3.10.1",


### PR DESCRIPTION
As a follow-up to https://github.com/apifytech/apify-js/issues/456, I would like to propose the following implementation for an integration of blocking ads, trackers and annoyances into `Apify`. The expected benefits are faster crawls thanks to the reduced number of requests (all ads and trackers can be blocked, leading to less requests, less JavaScript to run and less data to download). The breakage should also be fairly low thanks to the use of actively maintained lists from Easylist and uBlock Origin projects (updated continuously).

The implementation is strongly inspired by the existing utils used to block requests (e.g. `blockRequests()`) and all the new logic is located inside of `src/puppeteer_utils.js`. The new `blockAdsAndTrackers(page, [options])` can be used be used to enable blocking of request based on rules found on the widely-used subscriptions: Easylist, uBlock Origin filters, etc. (see the docstring for more information). The following behaviors are implemented and can be selected when calling `blockAdsAndTrackers()`:

- Block ads only (default behavior)
- Block ads and trackers (using `blockTrackers` options)
- Block ads, trackers and annoyances, such as cookie popups, banners, etc. (using `blockAnnoyances`)

There are things which I did not commit in this initial PR as I was not sure if I should do it, or if this would be done as part of the releasing process:
- Re-generating the docs
- Re-generating the types
- Updating CHANGELOG.md

I am happy to receive any feedback on this and make changes accordingly,
Best,