### PR TITLE
needs to include types-apify, fix log as `any`

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "homepage": "https://sdk.apify.com/",
     "files": [
         "build",
-        "types"
+        "types",
+        "types-apify"
     ],
     "scripts": {
         "build": "npm run clean && tsc -p tsconfig.json && node ./tools/typescript_fixes.js",


### PR DESCRIPTION
the folder is needed for "local" types of external apify modules