### PR TITLE
Web - attempt to fix text formatting of buttons

### DIFF
--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -40,3 +40,7 @@ input#search_input_react::placeholder {
 .projectTitle {
     color: #000;
 }
+
+.function-name-prevnext {
+    text-transform: none;
+}

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -41,6 +41,7 @@ input#search_input_react::placeholder {
     color: #000;
 }
 
-.function-name-prevnext {
+/* The prev/next buttons are capitalized by default, which makes then unreadable. This fixes it. */
+.docs-prev span, .docs-next span {
     text-transform: none;
 }


### PR DESCRIPTION
Attempt to make these buttons more readable:

<img width="837" alt="Screenshot 2020-04-09 at 15 28 59" src="https://user-images.githubusercontent.com/10612996/78900256-df576e00-7a76-11ea-9fac-efdfe639809a.png">
