### PR TITLE
Fix/save snapshot file format

### DIFF
--- a/src/puppeteer_utils.js
+++ b/src/puppeteer_utils.js
@@ -6,6 +6,7 @@ import { checkParamOrThrow } from 'apify-client/build/utils';
 import { checkParamPrototypeOrThrow } from 'apify-shared/utilities';
 import * as LruCache from 'apify-shared/lru_cache';
 import { Page, Response, DirectNavigationOptions } from 'puppeteer'; // eslint-disable-line no-unused-vars
+import { isAtHome } from './utils';
 import log from './utils_log';
 
 import { RequestQueue, RequestQueueLocal } from './request_queue';
@@ -545,12 +546,14 @@ const saveSnapshot = async (page, options = {}) => {
         const store = await openKeyValueStore(keyValueStoreName);
 
         if (saveScreenshot) {
+            const screenshotName = isAtHome() ? `${key}.jpg` : key;
             const screenshotBuffer = await page.screenshot({ fullPage: true, screenshotQuality, type: 'jpeg' });
-            await store.setValue(key, screenshotBuffer, { contentType: 'image/jpeg' });
+            await store.setValue(screenshotName, screenshotBuffer, { contentType: 'image/jpeg' });
         }
         if (saveHtml) {
+            const htmlName = isAtHome() ? `${key}.html` : key;
             const html = await page.content();
-            await store.setValue(key, html, { contentType: 'text/html' });
+            await store.setValue(htmlName, html, { contentType: 'text/html' });
         }
     } catch (e) {
         // I like this more than having to investigate stack trace

--- a/src/puppeteer_utils.js
+++ b/src/puppeteer_utils.js
@@ -546,11 +546,11 @@ const saveSnapshot = async (page, options = {}) => {
 
         if (saveScreenshot) {
             const screenshotBuffer = await page.screenshot({ fullPage: true, screenshotQuality, type: 'jpeg' });
-            await store.setValue(`${key}.jpg`, screenshotBuffer, { contentType: 'image/jpeg' });
+            await store.setValue(key, screenshotBuffer, { contentType: 'image/jpeg' });
         }
         if (saveHtml) {
             const html = await page.content();
-            await store.setValue(`${key}.html`, html, { contentType: 'text/html' });
+            await store.setValue(key, html, { contentType: 'text/html' });
         }
     } catch (e) {
         // I like this more than having to investigate stack trace

--- a/test/puppeteer_utils.test.js
+++ b/test/puppeteer_utils.test.js
@@ -408,6 +408,7 @@ describe('Apify.utils.puppeteer', () => {
             expect(stub3.calledWithExactly('TEST.jpg', screenshot, { contentType: 'image/jpeg' })).toBe(true);
             expect(stub3.calledWithExactly('TEST.html', contentHTML, { contentType: 'text/html' })).toBe(true);
 
+            process.env[ENV_VARS.IS_AT_HOME] = 0;
             mock.verify();
         } finally {
             await browser.close();

--- a/test/puppeteer_utils.test.js
+++ b/test/puppeteer_utils.test.js
@@ -406,6 +406,7 @@ describe('Apify.utils.puppeteer', () => {
 
             expect(stub3.calledWithExactly('TEST.jpg', screenshot, { contentType: 'image/jpeg' })).toBe(true);
             expect(stub3.calledWithExactly('TEST.html', contentHTML, { contentType: 'text/html' })).toBe(true);
+            delete process.env[ENV_VARS.IS_AT_HOME];
 
             mock.verify();
         } finally {

--- a/test/puppeteer_utils.test.js
+++ b/test/puppeteer_utils.test.js
@@ -375,8 +375,8 @@ describe('Apify.utils.puppeteer', () => {
 
             await Apify.utils.puppeteer.saveSnapshot(page, { key: 'TEST', keyValueStoreName: 'TEST-STORE', screenshotQuality: 60 });
 
-            expect(stub.calledWithExactly('TEST.jpg', screenshot, { contentType: 'image/jpeg' })).toBe(true);
-            expect(stub.calledWithExactly('TEST.html', contentHTML, { contentType: 'text/html' })).toBe(true);
+            expect(stub.calledWithExactly('TEST', screenshot, { contentType: 'image/jpeg' })).toBe(true);
+            expect(stub.calledWithExactly('TEST', contentHTML, { contentType: 'text/html' })).toBe(true);
 
             // Test saving only image
             const object2 = { setValue: async () => {} };
@@ -389,7 +389,7 @@ describe('Apify.utils.puppeteer', () => {
 
             // Default quality is 50
             const screenshot2 = await page.screenshot({ fullPage: true, type: 'jpeg', screenshotQuality: 50 });
-            expect(stub2.calledOnceWithExactly('SNAPSHOT.jpg', screenshot2, { contentType: 'image/jpeg' })).toBe(true);
+            expect(stub2.calledOnceWithExactly('SNAPSHOT', screenshot2, { contentType: 'image/jpeg' })).toBe(true);
 
             mock.verify();
         } finally {

--- a/test/puppeteer_utils.test.js
+++ b/test/puppeteer_utils.test.js
@@ -2,6 +2,7 @@ import sinon from 'sinon';
 import path from 'path';
 import Apify from '../build/index';
 import * as keyValueStore from '../build/key_value_store';
+import * as utils from '../build/utils';
 import LocalStorageDirEmulator from './local_storage_dir_emulator';
 
 const { utils: { log } } = Apify;
@@ -375,8 +376,10 @@ describe('Apify.utils.puppeteer', () => {
 
             await Apify.utils.puppeteer.saveSnapshot(page, { key: 'TEST', keyValueStoreName: 'TEST-STORE', screenshotQuality: 60 });
 
-            expect(stub.calledWithExactly('TEST', screenshot, { contentType: 'image/jpeg' })).toBe(true);
-            expect(stub.calledWithExactly('TEST', contentHTML, { contentType: 'text/html' })).toBe(true);
+            const screenshotName = utils.isAtHome() ? 'TEST.jpg' : 'TEST';
+            expect(stub.calledWithExactly(screenshotName, screenshot, { contentType: 'image/jpeg' })).toBe(true);
+            const htmlName = utils.isAtHome() ? 'TEST.html' : 'TEST';
+            expect(stub.calledWithExactly(htmlName, contentHTML, { contentType: 'text/html' })).toBe(true);
 
             // Test saving only image
             const object2 = { setValue: async () => {} };
@@ -389,7 +392,8 @@ describe('Apify.utils.puppeteer', () => {
 
             // Default quality is 50
             const screenshot2 = await page.screenshot({ fullPage: true, type: 'jpeg', screenshotQuality: 50 });
-            expect(stub2.calledOnceWithExactly('SNAPSHOT', screenshot2, { contentType: 'image/jpeg' })).toBe(true);
+            const screenshot2Name = utils.isAtHome() ? 'SNAPSHOT.jpg' : 'SNAPSHOT';
+            expect(stub2.calledOnceWithExactly(screenshot2Name, screenshot2, { contentType: 'image/jpeg' })).toBe(true);
 
             mock.verify();
         } finally {

--- a/test/puppeteer_utils.test.js
+++ b/test/puppeteer_utils.test.js
@@ -3,7 +3,6 @@ import path from 'path';
 import { ENV_VARS } from 'apify-shared/consts';
 import Apify from '../build/index';
 import * as keyValueStore from '../build/key_value_store';
-import * as utils from '../build/utils';
 import LocalStorageDirEmulator from './local_storage_dir_emulator';
 
 const { utils: { log } } = Apify;
@@ -408,7 +407,6 @@ describe('Apify.utils.puppeteer', () => {
             expect(stub3.calledWithExactly('TEST.jpg', screenshot, { contentType: 'image/jpeg' })).toBe(true);
             expect(stub3.calledWithExactly('TEST.html', contentHTML, { contentType: 'text/html' })).toBe(true);
 
-            process.env[ENV_VARS.IS_AT_HOME] = 0;
             mock.verify();
         } finally {
             await browser.close();


### PR DESCRIPTION
Fixed creating file format extensions by `saveSnapshot()` method (locally run)  #647 