### PR TITLE
cookie expires uses seconds not milliseconds

### DIFF
--- a/src/session_pool/session.js
+++ b/src/session_pool/session.js
@@ -305,7 +305,7 @@ export class Session {
      */
     _puppeteerCookieToTough(puppeteerCookie) {
         const isExpiresValid = puppeteerCookie.expires && typeof puppeteerCookie.expires === 'number';
-        const expires = isExpiresValid ? new Date(puppeteerCookie.expires) : this._getDefaultCookieExpirationDate(this.maxAgeSecs);
+        const expires = isExpiresValid ? new Date(puppeteerCookie.expires * 1000) : this._getDefaultCookieExpirationDate(this.maxAgeSecs);
         return new Cookie({
             key: puppeteerCookie.name,
             value: puppeteerCookie.value,


### PR DESCRIPTION
I was thinking it was a bug in my code, but the `Date` is using the parsed `expires` as seconds instead of milliseconds, making nearly all cookies "expires" as somewhere around `1970-01-xx` (when using `page.cookies()` / `session.setPuppeteerCookies()`). ToughCookie seems to parse `expires` and `maxAge` to unix timestamp seconds and seems correct: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie

EDIT: thinking more about this, there should be tests covering the verification of expiry on integration tests

EDIT2: Doesn't cover -1, saw some expires being `1969` instead of `1970`