### PR TITLE
Fix tests

### DIFF
--- a/src/dataset.js
+++ b/src/dataset.js
@@ -3,9 +3,9 @@ import { promisify } from 'util';
 import * as fs from 'fs-extra';
 import * as _ from 'underscore';
 import { leftpad } from 'apify-shared/utilities';
-import * as LruCache from 'apify-shared/lru_cache';
 import { checkParamOrThrow } from 'apify-client/build/utils';
 import { ENV_VARS, LOCAL_STORAGE_SUBDIRS, MAX_PAYLOAD_SIZE_BYTES } from 'apify-shared/consts';
+import globalCache from './global_cache';
 import { apifyClient, ensureDirExists, openRemoteStorage, openLocalStorage, ensureTokenOrLocalStorageEnvExists } from './utils';
 import log from './utils_log';
 
@@ -13,7 +13,7 @@ export const DATASET_ITERATORS_DEFAULT_LIMIT = 10000;
 export const LOCAL_STORAGE_SUBDIR = LOCAL_STORAGE_SUBDIRS.datasets;
 export const LOCAL_FILENAME_DIGITS = 9;
 export const LOCAL_GET_ITEMS_DEFAULT_LIMIT = 250000;
-const MAX_OPENED_STORES = 1000;
+const MAX_OPENED_DATASETS = 1000;
 const SAFETY_BUFFER_PERCENT = 0.01 / 100; // 0.01%
 
 const writeFilePromised = promisify(fs.writeFile);
@@ -25,7 +25,7 @@ const emptyDirPromised = promisify(fs.emptyDir);
 const getLocaleFilename = index => `${leftpad(index, LOCAL_FILENAME_DIGITS, 0)}.json`;
 
 const { datasets } = apifyClient;
-const datasetsCache = new LruCache({ maxLength: MAX_OPENED_STORES }); // Open Datasets are stored here.
+const datasetsCache = globalCache.create('dataset-cache', MAX_OPENED_DATASETS); // Open Datasets are stored here.
 
 /**
  * Accepts a JSON serializable object as an input, validates its serializability,

--- a/src/global_cache.js
+++ b/src/global_cache.js
@@ -1,0 +1,30 @@
+import * as LruCache from 'apify-shared/lru_cache';
+
+/**
+ * Used to manage all globally created caches, such as request queue cache
+ * or dataset cache. Before creation of this class, those caches were
+ * created as module scoped globals - untouchable. This proved problematic
+ * especially in tests, where caches would prevent test separation.
+ */
+class GlobalCache {
+    constructor() {
+        this.caches = new Map();
+    }
+
+    create(name, maxSize) {
+        const newCache = new LruCache({ maxLength: maxSize });
+        this.caches.set(name, newCache);
+        return newCache;
+    }
+
+    clear(name) {
+        const cache = this.caches.get(name);
+        cache.clear();
+    }
+
+    clearAll() {
+        this.caches.forEach(cache => cache.clear());
+    }
+}
+
+export default new GlobalCache();

--- a/src/key_value_store.js
+++ b/src/key_value_store.js
@@ -3,7 +3,6 @@ import * as path from 'path';
 import { promisify } from 'util';
 import * as contentTypeParser from 'content-type';
 import * as mime from 'mime-types';
-import * as LruCache from 'apify-shared/lru_cache';
 import { KEY_VALUE_STORE_KEY_REGEX } from 'apify-shared/regexs';
 import { ENV_VARS, LOCAL_STORAGE_SUBDIRS, KEY_VALUE_STORE_KEYS } from 'apify-shared/consts';
 import { jsonStringifyExtended } from 'apify-shared/utilities';
@@ -12,6 +11,7 @@ import {
     addCharsetToContentType, apifyClient, ensureDirExists, openRemoteStorage, openLocalStorage, ensureTokenOrLocalStorageEnvExists,
 } from './utils';
 import { APIFY_API_BASE_URL } from './constants';
+import globalCache from './global_cache';
 import log from './utils_log';
 
 export const LOCAL_STORAGE_SUBDIR = LOCAL_STORAGE_SUBDIRS.keyValueStores;
@@ -27,7 +27,7 @@ const statPromised = promisify(fs.stat);
 const emptyDirPromised = promisify(fs.emptyDir);
 
 const { keyValueStores } = apifyClient;
-const storesCache = new LruCache({ maxLength: MAX_OPENED_STORES }); // Open key-value stores are stored here.
+const storesCache = globalCache.create('key-value-store-cache', MAX_OPENED_STORES); // Open key-value stores are stored here.
 
 /**
  * Helper function to validate params of *.getValue().

--- a/src/request_queue.js
+++ b/src/request_queue.js
@@ -7,6 +7,7 @@ import * as ListDictionary from 'apify-shared/list_dictionary';
 import { ENV_VARS, LOCAL_STORAGE_SUBDIRS, REQUEST_QUEUE_HEAD_MAX_LIMIT } from 'apify-shared/consts';
 import { checkParamPrototypeOrThrow, cryptoRandomObjectId } from 'apify-shared/utilities';
 import Request, { RequestOptions } from './request'; // eslint-disable-line import/named,no-unused-vars
+import globalCache from './global_cache';
 import {
     ensureDirExists, apifyClient, openRemoteStorage, openLocalStorage, ensureTokenOrLocalStorageEnvExists, sleep,
 } from './utils';
@@ -36,7 +37,7 @@ const RECENTLY_HANDLED_CACHE_SIZE = 1000;
 export const STORAGE_CONSISTENCY_DELAY_MILLIS = 3000;
 
 const { requestQueues } = apifyClient;
-const queuesCache = new LruCache({ maxLength: MAX_OPENED_QUEUES }); // Open queues are stored here.
+const queuesCache = globalCache.create('request-queue-cache', MAX_OPENED_QUEUES); // Open queues are stored here.
 
 /**
  * Helper function to validate params of *.addRequest().

--- a/test/_helper.js
+++ b/test/_helper.js
@@ -1,8 +1,5 @@
 import fs from 'fs-extra';
-import path from 'path';
 import { ENV_VARS } from 'apify-shared/consts';
-
-export const LOCAL_STORAGE_DIR = path.join(__dirname, '..', 'tmp', 'local-emulation-dir');
 
 // Log unhandled rejections.
 // process.on('unhandledRejection', (err) => {
@@ -12,13 +9,6 @@ export const LOCAL_STORAGE_DIR = path.join(__dirname, '..', 'tmp', 'local-emulat
 //     console.log(err);
 //     process.exit(1);
 // });
-
-
-export const emptyLocalStorageSubdir = (subdir) => {
-    const fullPath = path.resolve(path.join(LOCAL_STORAGE_DIR, subdir));
-
-    fs.emptyDirSync(fullPath);
-};
 
 export const expectNotUsingLocalStorage = () => expect(process.env[ENV_VARS.LOCAL_STORAGE_DIR]).toBeUndefined();
 

--- a/test/crawlers/basic_crawler.test.js
+++ b/test/crawlers/basic_crawler.test.js
@@ -12,18 +12,16 @@ import LocalStorageDirEmulator from '../local_storage_dir_emulator';
 describe('BasicCrawler', () => {
     let logLevel;
     let localStorageEmulator;
-    let LOCAL_STORAGE_DIR;
+    let localStorageDir;
 
     beforeAll(async () => {
         logLevel = log.getLevel();
         log.setLevel(log.LEVELS.OFF);
         localStorageEmulator = new LocalStorageDirEmulator();
-        await localStorageEmulator.init();
-        LOCAL_STORAGE_DIR = localStorageEmulator.localStorageDir;
     });
 
     beforeEach(async () => {
-        await localStorageEmulator.clean();
+        localStorageDir = await localStorageEmulator.init();
     });
 
     afterAll(async () => {
@@ -265,7 +263,7 @@ describe('BasicCrawler', () => {
 
     test('should also support RequestQueueLocal', () => {
         const requestQueue = new RequestQueue('xxx');
-        const requestQueueLocal = new RequestQueueLocal('xxx', LOCAL_STORAGE_DIR);
+        const requestQueueLocal = new RequestQueueLocal('xxx', localStorageDir);
         const handleRequestFunction = () => {};
 
         expect(() => new Apify.BasicCrawler({ handleRequestFunction, requestQueue })).not.toThrowError();

--- a/test/crawlers/cheerio_crawler.test.js
+++ b/test/crawlers/cheerio_crawler.test.js
@@ -95,11 +95,10 @@ describe('CheerioCrawler', () => {
         server = await startExpressAppPromise(app, 0);
         port = server.address().port; //eslint-disable-line
         localStorageEmulator = new LocalStorageDirEmulator();
-        await localStorageEmulator.init();
     });
 
-    afterEach(async () => {
-        await localStorageEmulator.clean();
+    beforeEach(async () => {
+        await localStorageEmulator.init();
     });
 
     afterAll(async () => {
@@ -533,7 +532,7 @@ describe('CheerioCrawler', () => {
             }
         });
 
-        test('always when using "!"', async () => {
+        test('always when forced', async () => {
             const forceResponseEncoding = 'win1250';
             const buf = iconv.encode(html, forceResponseEncoding);
             // Ensure it's really encoded.
@@ -554,11 +553,6 @@ describe('CheerioCrawler', () => {
                 expect(string).toBe(html);
             }
         });
-    });
-
-    test('should encode responses using responseEncoding', async () => {
-
-
     });
 
     describe('proxy', () => {
@@ -719,7 +713,6 @@ describe('CheerioCrawler', () => {
         let requestList;
 
         beforeEach(async () => {
-            await localStorageEmulator.clean();
             requestList = await Apify.openRequestList('test', sources.slice());
         });
 

--- a/test/crawlers/puppeteer_crawler.test.js
+++ b/test/crawlers/puppeteer_crawler.test.js
@@ -14,10 +14,9 @@ describe('PuppeteerCrawler', () => {
         logLevel = log.getLevel();
         log.setLevel(log.LEVELS.ERROR);
         localStorageEmulator = new LocalStorageDirEmulator();
-        await localStorageEmulator.init();
     });
-    afterEach(async () => {
-        await localStorageEmulator.clean();
+    beforeEach(async () => {
+        await localStorageEmulator.init();
     });
     afterAll(async () => {
         log.setLevel(logLevel);

--- a/test/dataset.test.js
+++ b/test/dataset.test.js
@@ -18,8 +18,6 @@ describe('dataset', () => {
     beforeAll(async () => {
         apifyClient.setOptions({ token: 'xxx' });
         localStorageEmulator = new LocalStorageDirEmulator();
-        await localStorageEmulator.init();
-        localStorageDir = localStorageEmulator.localStorageDir; // eslint-disable-line
     });
 
     afterAll(async () => {
@@ -28,7 +26,7 @@ describe('dataset', () => {
     });
 
     beforeEach(async () => {
-        await localStorageEmulator.clean();
+        localStorageDir = await localStorageEmulator.init();
     });
 
     const read = (datasetName, index) => {

--- a/test/key_value_store.test.js
+++ b/test/key_value_store.test.js
@@ -16,8 +16,6 @@ describe('KeyValueStore', () => {
     beforeAll(async () => {
         apifyClient.setOptions({ token: 'xxx' });
         localStorageEmulator = new LocalStorageDirEmulator();
-        await localStorageEmulator.init();
-        localStorageDir = localStorageEmulator.localStorageDir; // eslint-disable-line
     });
 
     afterAll(async () => {
@@ -26,7 +24,7 @@ describe('KeyValueStore', () => {
     });
 
     beforeEach(async () => {
-        await localStorageEmulator.clean();
+        localStorageDir = await localStorageEmulator.init();
     });
 
     describe('maybeStringify()', () => {

--- a/test/puppeteer_pool.test.js
+++ b/test/puppeteer_pool.test.js
@@ -656,11 +656,10 @@ describe('PuppeteerPool', () => {
 
         beforeAll(async () => {
             localStorageEmulator = new LocalStorageDirEmulator();
-            await localStorageEmulator.init();
         });
 
-        afterEach(async () => {
-            await localStorageEmulator.clean();
+        beforeEach(async () => {
+            await localStorageEmulator.init();
         });
 
         afterAll(async () => {

--- a/test/puppeteer_utils.test.js
+++ b/test/puppeteer_utils.test.js
@@ -15,11 +15,10 @@ describe('Apify.utils.puppeteer', () => {
         ll = log.getLevel();
         log.setLevel(log.LEVELS.ERROR);
         localStorageEmulator = new LocalStorageDirEmulator();
-        await localStorageEmulator.init();
     });
 
     beforeEach(async () => {
-        await localStorageEmulator.clean();
+        await localStorageEmulator.init();
     });
 
     afterAll(async () => {

--- a/test/request_queue.test.js
+++ b/test/request_queue.test.js
@@ -28,8 +28,6 @@ describe('RequestQueue', () => {
         beforeAll(async () => {
             apifyClient.setOptions({ token: 'xxx' });
             localStorageEmulator = new LocalStorageDirEmulator();
-            await localStorageEmulator.init();
-            localStorageDir = localStorageEmulator.localStorageDir; // eslint-disable-line
         });
 
         afterAll(async () => {
@@ -38,7 +36,7 @@ describe('RequestQueue', () => {
         });
 
         beforeEach(async () => {
-            await localStorageEmulator.clean();
+            localStorageDir = await localStorageEmulator.init();
         });
 
         test('should work', async () => {

--- a/test/stealth/stealth.test.js
+++ b/test/stealth/stealth.test.js
@@ -20,11 +20,10 @@ describe('Stealth - testing headless chrome hiding tricks', () => {
 
     beforeAll(async () => {
         localStorageEmulator = new LocalStorageDirEmulator();
-        await localStorageEmulator.init();
     });
 
     beforeEach(async () => {
-        await localStorageEmulator.clean();
+        await localStorageEmulator.init();
     });
 
     afterAll(async () => {


### PR DESCRIPTION
In certain cases, a combination of the local storage emulation and global storage caches caused tests to affect one another. This PR attempts to hotfix it by adding the ability to clear storage caches and making local storage emulator more robust.