### PR TITLE
Create issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Start with giving us feedback**
+It's hard to build software for people we've never met. Please spend 5 minutes to tell us how YOU are using the Apify SDK by filling out our [developer feedback survey](https://apify.typeform.com/to/eV6Rqb).
+
+**Now describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Add an example of code that produces the problem you're reporting.
+We should be able to copy your code, run it and get the same result.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**System information:**
+ - OS: [e.g. MacOS]
+ - Node.js version [e.g. 22]
+ - Apify SDK version [e.g. 0.20.4]
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
I created an issue template for SDK. It's actually quite nice, the issue template builder. And you can create org-wide templates. What do you think?