### PR TITLE
Add option to disable outdated warning

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -40,6 +40,12 @@ const URL_NO_COMMAS_REGEX = RegExp('https?://(www\\.)?[\\p{L}0-9][-\\p{L}0-9@:%.
  */
 const URL_WITH_COMMAS_REGEX = RegExp('https?://(www\\.)?[\\p{L}0-9][-\\p{L}0-9@:%._\\+~#=]{0,254}[\\p{L}0-9]\\.[a-z]{2,63}(:\\d{1,5})?(/[-\\p{L}0-9@:%_\\+,.~#?&//=\\(\\)]*)?', 'giu'); // eslint-disable-line
 
+/**
+ * Allows turning off the warning that gets printed whenever an actor is run with an outdated SDK on the Apify Platform.
+ * @type {string}
+ */
+const DISABLE_OUTDATED_WARNING = 'APIFY_DISABLE_OUTDATED_WARNING';
+
 const ensureDirPromised = util.promisify(fsExtra.ensureDir);
 const psTreePromised = util.promisify(psTree);
 
@@ -672,6 +678,7 @@ export const snakeCaseToCamelCase = (snakeCaseStr) => {
  * @ignore
  */
 export const printOutdatedSdkWarning = () => {
+    if (process.env[DISABLE_OUTDATED_WARNING]) return;
     const latestApifyVersion = process.env[ENV_VARS.SDK_LATEST_VERSION];
     if (!latestApifyVersion || !semver.lt(apifyVersion, latestApifyVersion)) return;
 

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -903,6 +903,13 @@ describe('utils.printOutdatedSdkWarning()', () => {
         utils.printOutdatedSdkWarning();
     });
 
+    test('should do nothing when APIFY_DISABLE_OUTDATED_WARNING is set', () => {
+        process.env.APIFY_DISABLE_OUTDATED_WARNING = '1';
+        logMock.expects('warning').never();
+        utils.printOutdatedSdkWarning();
+        delete process.env.APIFY_DISABLE_OUTDATED_WARNING;
+    });
+
     test('should correctly work when outdated', () => {
         process.env[ENV_VARS.SDK_LATEST_VERSION] = semver.inc(currentVersion, 'minor');
         console.log(process.env[ENV_VARS.SDK_LATEST_VERSION]);


### PR DESCRIPTION
Fix #699. While doing this I found that the warning is actually printed only when `APIFY_SDK_LATEST_VERSION` is present, which means it's never printed locally and is only printed on platform.

We could prevent adding this env var for public actors to achieve a similar result to this PR.