### PR TITLE
Feature/proxy configuration custom urls

### DIFF
--- a/src/crawlers/basic_crawler.js
+++ b/src/crawlers/basic_crawler.js
@@ -104,6 +104,7 @@ const SAFE_MIGRATION_WAIT_MILLIS = 20000;
  *   If set to true. Basic crawler will initialize the  {@link SessionPool} with the corresponding `sessionPoolOptions`.
  *   The session instance will be than available in the `handleRequestFunction`.
  * @property {SessionPoolOptions} [sessionPoolOptions] The configuration options for {SessionPool} to use.
+ */
 
 /**
  * Provides a simple framework for parallel crawling of web pages.

--- a/src/crawlers/basic_crawler.js
+++ b/src/crawlers/basic_crawler.js
@@ -18,7 +18,6 @@ import Request from '../request';
 import { QueueOperationInfo } from '../request_queue';
 import { Session } from '../session_pool/session';
 import { SessionPoolOptions } from '../session_pool/session_pool';
-import { ProxyConfiguration, ProxyInfo } from '../proxy_configuration';
 /* eslint-enable no-unused-vars,import/named,import/no-duplicates,import/order */
 
 /**
@@ -45,7 +44,6 @@ const SAFE_MIGRATION_WAIT_MILLIS = 20000;
  *   request: Request,
  *   autoscaledPool: AutoscaledPool,
  *   session: Session,
- *   proxyInfo: ProxyInfo
  * }
  * ```
  *   where the {@link Request} instance represents the URL to crawl.
@@ -106,14 +104,6 @@ const SAFE_MIGRATION_WAIT_MILLIS = 20000;
  *   If set to true. Basic crawler will initialize the  {@link SessionPool} with the corresponding `sessionPoolOptions`.
  *   The session instance will be than available in the `handleRequestFunction`.
  * @property {SessionPoolOptions} [sessionPoolOptions] The configuration options for {SessionPool} to use.
- * @property {ProxyConfiguration} [proxyConfiguration]
- *   If set, `BasicCrawler` will be configured to use
- *   [Apify Proxy](https://my.apify.com/proxy) for all connections.
- *   For more information, see the [documentation](https://docs.apify.com/proxy)
- *
- *   The proxyConfiguration only provides access to the proxyInfo object but the `BasicCrawler` itself
- *   is not responsible for using that proxy information to make the proxied HTTP requests.
- */
 
 /**
  * Provides a simple framework for parallel crawling of web pages.
@@ -196,7 +186,6 @@ class BasicCrawler {
             },
             maxRequestRetries = 3,
             maxRequestsPerCrawl,
-            proxyConfiguration,
             autoscaledPoolOptions = {},
             sessionPoolOptions = {},
             useSessionPool = false,
@@ -210,7 +199,6 @@ class BasicCrawler {
         } = options;
 
         checkParamPrototypeOrThrow(requestList, 'options.requestList', RequestList, 'Apify.RequestList', true);
-        checkParamPrototypeOrThrow(proxyConfiguration, 'options.proxyConfiguration', ProxyConfiguration, 'Apify.proxyConfiguration', true);
         checkParamPrototypeOrThrow(requestQueue, 'options.requestQueue', [RequestQueue, RequestQueueLocal], 'Apify.RequestQueue', true);
         checkParamOrThrow(handleRequestFunction, 'options.handleRequestFunction', 'Function');
         checkParamOrThrow(handleRequestTimeoutSecs, 'options.handleRequestTimeoutSecs', 'Number');
@@ -228,7 +216,6 @@ class BasicCrawler {
         this.log = log;
         this.requestList = requestList;
         this.requestQueue = requestQueue;
-        this.proxyConfiguration = proxyConfiguration;
         this.handleRequestFunction = handleRequestFunction;
         this.handleRequestTimeoutMillis = handleRequestTimeoutSecs * 1000;
         this.handleFailedRequestFunction = handleFailedRequestFunction;
@@ -393,16 +380,11 @@ class BasicCrawler {
 
         let request;
         let session;
-        let proxyInfo;
 
         if (this.useSessionPool) {
             [request, session] = await Promise.all([this._fetchNextRequest(), this.sessionPool.getSession()]);
         } else {
             request = await this._fetchNextRequest();
-        }
-
-        if (this.proxyConfiguration) {
-            proxyInfo = this.proxyConfiguration.getInfo(session ? session.id : undefined);
         }
 
         if (!request) return;
@@ -414,7 +396,7 @@ class BasicCrawler {
         this.stats.startJob(statisticsId);
         try {
             await addTimeoutToPromise(
-                this.handleRequestFunction({ request, autoscaledPool: this.autoscaledPool, session, proxyInfo }),
+                this.handleRequestFunction({ request, autoscaledPool: this.autoscaledPool, session }),
                 this.handleRequestTimeoutMillis,
                 `handleRequestFunction timed out after ${this.handleRequestTimeoutMillis / 1000} seconds.`,
             );
@@ -537,7 +519,6 @@ export default BasicCrawler;
  *  to pause the crawler by calling {@link AutoscaledPool#pause}
  *  or to abort it by calling {@link AutoscaledPool#abort}.
  * @property {Session} [session]
- * @property {ProxyInfo} [proxyInfo]
  */
 
 /**

--- a/src/crawlers/cheerio_crawler.js
+++ b/src/crawlers/cheerio_crawler.js
@@ -137,8 +137,8 @@ const DEFAULT_AUTOSCALED_POOL_OPTIONS = {
  * @property {boolean} [ignoreSslErrors=true]
  *   If set to true, SSL certificate errors will be ignored.
  * @property {ProxyConfiguration} [proxyConfiguration]
- *   If set, `CheerioCrawler` will be configured for all connection to use
- *   [Apify Proxy](https://my.apify.com/proxy) or Proxy URLs provided and rotated according to the configuration.
+ *   If set, `CheerioCrawler` will be configured for all connections to use
+ *   [Apify Proxy](https://my.apify.com/proxy) or your own Proxy URLs provided and rotated according to the configuration.
  *   For more information, see the [documentation](https://docs.apify.com/proxy).
  * @property {HandleFailedRequest} [handleFailedRequestFunction]
  *   A function to handle requests that failed more than `option.maxRequestRetries` times.
@@ -589,7 +589,7 @@ class CheerioCrawler {
      * Combines the provided `requestOptions` with mandatory (non-overridable) values.
      * @param {Request} request
      * @param {Session} [session]
-     * @param {(string|null)} proxyUrl
+     * @param {string} [proxyUrl]
      * @ignore
      */
     _getRequestOptions(request, session, proxyUrl) {

--- a/src/crawlers/puppeteer_crawler.js
+++ b/src/crawlers/puppeteer_crawler.js
@@ -132,7 +132,7 @@ import { SessionPoolOptions } from '../session_pool/session_pool';
  * @property {boolean} [persistCookiesPerSession=false]
  *   Automatically saves cookies to Session. Works only if Session Pool is used.
  * @property {ProxyConfiguration} [proxyConfiguration]
- *  If set, `PuppeteerCrawler` will be configured for all connection to use
+ *   If set, `PuppeteerCrawler` will be configured for all connection to use
  *   [Apify Proxy](https://my.apify.com/proxy) or Proxy URLs provided and rotated according to the configuration.
  *   For more information, see the [documentation](https://docs.apify.com/proxy).
  */
@@ -250,6 +250,11 @@ class PuppeteerCrawler {
         checkParamOrThrow(useSessionPool, 'options.useSessionPool', 'Boolean');
         checkParamOrThrow(sessionPoolOptions, 'options.sessionPoolOptions', 'Object');
         checkParamOrThrow(persistCookiesPerSession, 'options.persistCookiesPerSession', 'Boolean');
+
+        if (proxyConfiguration && (launchPuppeteerOptions && launchPuppeteerOptions.proxyUrl)) {
+            throw new Error('It is not possible to combine "options.proxyConfiguration" together with '
+                + 'custom "proxyUrl" option from "options.launchPuppeteerOptions".');
+        }
 
         this.log = defaultLog.child({ prefix: 'PuppeteerCrawler' });
 

--- a/src/crawlers/puppeteer_crawler.js
+++ b/src/crawlers/puppeteer_crawler.js
@@ -132,8 +132,8 @@ import { SessionPoolOptions } from '../session_pool/session_pool';
  * @property {boolean} [persistCookiesPerSession=false]
  *   Automatically saves cookies to Session. Works only if Session Pool is used.
  * @property {ProxyConfiguration} [proxyConfiguration]
- *   If set, `PuppeteerCrawler` will be configured for all connection to use
- *   [Apify Proxy](https://my.apify.com/proxy) or Proxy URLs provided and rotated according to the configuration.
+ *   If set, `PuppeteerCrawler` will be configured for all connections to use
+ *   [Apify Proxy](https://my.apify.com/proxy) or your own Proxy URLs provided and rotated according to the configuration.
  *   For more information, see the [documentation](https://docs.apify.com/proxy).
  */
 
@@ -350,7 +350,8 @@ class PuppeteerCrawler {
         let proxyInfo;
         const page = await this.puppeteerPool.newPage();
 
-        const browserInstance = this.puppeteerPool.getBrowserInstance(page);
+        // eslint-disable-next-line no-underscore-dangle
+        const browserInstance = this.puppeteerPool._getBrowserInstance(page);
         if (this.sessionPool) {
             // eslint-disable-next-line prefer-destructuring
             session = browserInstance.session;

--- a/src/crawlers/puppeteer_crawler.js
+++ b/src/crawlers/puppeteer_crawler.js
@@ -1,6 +1,6 @@
 import { checkParamOrThrow } from 'apify-client/build/utils';
 import * as _ from 'underscore';
-import PuppeteerPool, { BROWSER_SESSION_KEY_NAME } from '../puppeteer_pool'; // eslint-disable-line import/no-duplicates
+import PuppeteerPool from '../puppeteer_pool'; // eslint-disable-line import/no-duplicates
 import { BASIC_CRAWLER_TIMEOUT_MULTIPLIER } from '../constants';
 import { gotoExtended } from '../puppeteer_utils';
 import { openSessionPool } from '../session_pool/session_pool'; // eslint-disable-line import/no-duplicates
@@ -132,9 +132,9 @@ import { SessionPoolOptions } from '../session_pool/session_pool';
  * @property {boolean} [persistCookiesPerSession=false]
  *   Automatically saves cookies to Session. Works only if Session Pool is used.
  * @property {ProxyConfiguration} [proxyConfiguration]
- *   If set, `PuppeteerCrawler` will be configured to use
- *   [Apify Proxy](https://my.apify.com/proxy) for all connections.
- *   For more information, see the [documentation](https://docs.apify.com/proxy)
+ *  If set, `PuppeteerCrawler` will be configured for all connection to use
+ *   [Apify Proxy](https://my.apify.com/proxy) or Proxy URLs provided and rotated according to the configuration.
+ *   For more information, see the [documentation](https://docs.apify.com/proxy).
  */
 
 /**
@@ -345,10 +345,10 @@ class PuppeteerCrawler {
         let proxyInfo;
         const page = await this.puppeteerPool.newPage();
 
+        const browserInstance = this.puppeteerPool.getBrowserInstance(page);
         if (this.sessionPool) {
-            const browser = page.browser();
-            session = browser[BROWSER_SESSION_KEY_NAME];
-
+            // eslint-disable-next-line prefer-destructuring
+            session = browserInstance.session;
 
             // setting cookies to page
             if (this.persistCookiesPerSession) {
@@ -357,7 +357,8 @@ class PuppeteerCrawler {
         }
 
         if (this.proxyConfiguration) {
-            proxyInfo = this.proxyConfiguration.getInfo(session ? session.id : undefined);
+            // eslint-disable-next-line prefer-destructuring
+            proxyInfo = browserInstance.proxyInfo;
         }
 
 

--- a/src/proxy_configuration.js
+++ b/src/proxy_configuration.js
@@ -40,14 +40,14 @@ const APIFY_PROXY_STATUS_URL = 'http://proxy.apify.com/?format=json';
  *   Custom proxies are not compatible with Apify Proxy and an attempt to use both
  *   configuration options will cause an error to be thrown on initialize.
  * @property {function} [newUrlFunction]
- *   Custom function that allows to generate the new Proxy URL dynamically. It gets the `sessionId` as a parameter
- *   and should always return stringified Proxy URL.
+ *   Custom function that allows you to generate the new proxy URL dynamically. It gets the `sessionId` as a parameter
+ *   and should always return stringified proxy URL.
  *   This function is used to generate the URL when {@link ProxyConfiguration.newUrl} or {@link ProxyConfiguration.newProxyInfo} is called.
  */
 
 /**
  * The main purpose of the ProxyInfo object is to provide information
- * about the proxy used by the crawler for the current request.
+ * about the current proxy connection used by the crawler for the request.
  * Outside of crawlers, you can get this object by calling {@link ProxyConfiguration.newProxyInfo}.
  *
  * **Example usage:**
@@ -67,7 +67,7 @@ const APIFY_PROXY_STATUS_URL = 'http://proxy.apify.com/?format=json';
  *   // ...
  *   proxyConfiguration,
  *   handlePageFunction: ({ proxyInfo }) => {
- *      // Getting used Proxy URL
+ *      // Getting used proxy URL
  *       const proxyUrl = proxyInfo.url;
  *
  *      // Getting ID of used Session
@@ -113,7 +113,7 @@ const APIFY_PROXY_STATUS_URL = 'http://proxy.apify.com/?format=json';
  * you need an Apify account and access to the selected proxies. If you provide no configuration option,
  * the proxies will be managed automatically using a smart algorithm.
  *
- * If you want to use your own proxies, use the `proxyUrls` option in the {@link ProxyConfigurationOptions}. Your list of proxy URLs will
+ * If you want to use your own proxies, use the {@link ProxyConfigurationOptions.proxyUrls} option. Your list of proxy URLs will
  * be rotated by the configuration if this option is provided.
  *
  * **Example usage:**
@@ -129,7 +129,7 @@ const APIFY_PROXY_STATUS_URL = 'http://proxy.apify.com/?format=json';
  *   // ...
  *   proxyConfiguration,
  *   handlePageFunction: ({ proxyInfo }) => {
- *      const usedProxyUrl = proxyInfo.url; // Getting the Proxy URL
+ *      const usedProxyUrl = proxyInfo.url; // Getting the proxy URL
  *   }
  * })
  *
@@ -164,22 +164,29 @@ export class ProxyConfiguration {
         checkParamOrThrow(password, 'opts.password', 'Maybe String');
         checkParamOrThrow(proxyUrls, 'options.proxyUrls', 'Maybe [String]');
         checkParamOrThrow(newUrlFunction, 'options.newUrlFunction', 'Maybe Function');
-        this._validateArgumentStructure(groupsToUse, countryCodeToUse, proxyUrls);
+
+        // Harder validation
+        if ((proxyUrls || newUrlFunction) && ((groupsToUse.length) || countryCodeToUse)) {
+            this._throwCannotCombineCustomWithApify();
+        }
+        if (proxyUrls) this._validateProxyUrls(proxyUrls);
+        if (countryCodeToUse) this._validateCountryCode(countryCodeToUse);
+        this._validateGroupsStructure(groupsToUse);
 
         this.groups = groupsToUse;
         this.countryCode = countryCodeToUse;
         this.password = password;
         this.hostname = hostname;
         this.port = port;
-        this.lastUsedCustomUrlIndex = 0;
+        this.nextCustomUrlIndex = 0;
         this.proxyUrls = proxyUrls;
-        this.usedproxyUrls = {};
+        this.usedProxyUrls = new Map();
         this.newUrlFunction = newUrlFunction;
     }
 
     /**
      * Loads proxy password if token is provided and checks access to Apify Proxy and provided proxy groups
-     * If Apify Proxy configuration is used.
+     * if Apify Proxy configuration is used.
      * Also checks if country has access to Apify Proxy groups if the country code is provided.
      *
      * You should use the {@link Apify.createProxyConfiguration} function to create a pre-initialized
@@ -188,7 +195,7 @@ export class ProxyConfiguration {
      * @returns {Promise<void>}
      */
     async initialize() {
-        if (!this.proxyUrls) {
+        if (!this.proxyUrls || this.newUrlFunction) {
             await this._setPasswordIfToken();
 
             await this._checkAccess();
@@ -197,11 +204,16 @@ export class ProxyConfiguration {
 
 
     /**
-     * Returns the URL of current proxy server with information about the Proxy Configuration.
-     * @param {string} sessionId
-     *  Proxy [Session](https://docs.apify.com/proxy/datacenter-proxy#session-persistence) identifier
-     *  to be used with requests.
-     *  All HTTP requests going through the proxy with the same session identifier
+     * This function creates a new {@link ProxyInfo} info object.
+     * It is used by CheerioCrawler and PuppeteerCrawler to generate proxy URLs and also to allow the user to inspect
+     * the currently used proxy via the handlePageFunction parameter: proxyInfo.
+     * Use it if you want to work with a rich representation of a proxy URL.
+     * If you need the URL string only, use {@link ProxyConfiguration.newUrl}.
+     * @param {string} [sessionId]
+     *  Represents the identifier of user {@link Session} that can be managed by the {@link SessionPool} or
+     *  you can use the Apify Proxy [Session](https://docs.apify.com/proxy/datacenter-proxy#session-persistence) identifier.
+     *
+     *  All the HTTP requests going through the proxy with the same session identifier
      *  will use the same target proxy server (i.e. the same IP address).
      *  The identifier can only contain the following characters: `0-9`, `a-z`, `A-Z`, `"."`, `"_"` and `"~"`.
      * @return {ProxyInfo} represents information about used proxy and its configuration.
@@ -210,7 +222,7 @@ export class ProxyConfiguration {
         if (sessionId) this._validateSessionArgumentStructure(sessionId);
         const url = this.newUrl(sessionId);
 
-        const { groups, countryCode, password, port, hostname } = this.proxyUrls ? new URL(url) : this;
+        const { groups, countryCode, password, port, hostname } = this.proxyUrls || this.newUrlFunction ? new URL(url) : this;
 
         return {
             sessionId,
@@ -224,11 +236,12 @@ export class ProxyConfiguration {
     }
 
     /**
-     * Returns the URL of current proxy server.
-     * @param {string} sessionId
-     *  Proxy [Session](https://docs.apify.com/proxy/datacenter-proxy#session-persistence) identifier
-     *  to be used with requests.
-     *  All HTTP requests going through the proxy with the same session identifier
+     * Returns a new stringified URL of the proxy server.
+     * @param {string} [sessionId]
+     *  Represents the identifier of user {@link Session} that can be managed by the {@link SessionPool} or
+     *  you can use the Apify Proxy [Session](https://docs.apify.com/proxy/datacenter-proxy#session-persistence) identifier.
+     *
+     *  All the HTTP requests going through the proxy with the same session identifier
      *  will use the same target proxy server (i.e. the same IP address).
      *  The identifier can only contain the following characters: `0-9`, `a-z`, `A-Z`, `"."`, `"_"` and `"~"`.
      * @return {string} represents the proxy URL.
@@ -236,7 +249,7 @@ export class ProxyConfiguration {
     newUrl(sessionId) {
         if (sessionId) this._validateSessionArgumentStructure(sessionId);
         if (this.newUrlFunction) {
-            return this._checkNewUrlFunctionReturnValue(sessionId);
+            return this._callNewUrlFunction(sessionId);
         }
         if (this.proxyUrls) {
             return this._handleCustomUrl(sessionId);
@@ -249,8 +262,8 @@ export class ProxyConfiguration {
 
     /**
      * Returns proxy username.
+     * @param {string} [sessionId]
      * @return {string} the proxy username
-     * @param {string} sessionId
      * @ignore
      */
     _getUsername(sessionId) {
@@ -314,31 +327,31 @@ export class ProxyConfiguration {
 
     /**
      * Handles custom url rotation with session
-     * @param {string} sessionId
+     * @param {string} [sessionId]
      * @returns {string} url
      * @ignore
      */
     _handleCustomUrl(sessionId) {
         let customUrlToUse;
         if (sessionId) {
-            if (this.usedproxyUrls.hasOwnProperty(sessionId)) {  // eslint-disable-line
-                customUrlToUse = this.proxyUrls[this.usedproxyUrls[sessionId]];
+            if (this.usedProxyUrls.has(sessionId)) {
+                customUrlToUse = this.usedProxyUrls.get(sessionId);
             } else {
-                this.usedproxyUrls[sessionId] = this.lastUsedCustomUrlIndex++ % this.proxyUrls.length;
-                customUrlToUse = this.proxyUrls[this.usedproxyUrls[sessionId]];
+                customUrlToUse = this.proxyUrls[this.nextCustomUrlIndex++ % this.proxyUrls.length];
+                this.usedProxyUrls.set(sessionId, customUrlToUse);
             }
         } else {
-            customUrlToUse = this.proxyUrls[this.lastUsedCustomUrlIndex++ % this.proxyUrls.length];
+            customUrlToUse = this.proxyUrls[this.nextCustomUrlIndex++ % this.proxyUrls.length];
         }
         return customUrlToUse;
     }
 
     /**
-     * Checks return value of a custom newUrlFunction
-     * @param {string} sessionId
+     * Calls the custom newUrlFunction and checks format of its return value
+     * @param {string} [sessionId]
      * @ignore
      */
-    _checkNewUrlFunctionReturnValue(sessionId) {
+    _callNewUrlFunction(sessionId) {
         const urlToReturn = this.newUrlFunction(sessionId);
         try {
             // eslint-disable-next-line no-new
@@ -359,31 +372,40 @@ export class ProxyConfiguration {
     }
 
     /**
-     * Validates groups and countryCode options correct structure
+     * Validates groups option structure
      * @param {string[]} groups
-     * @param {string} countryCode
-     * @param {string[]} proxyUrls
      * @ignore
      */
-    _validateArgumentStructure(groups, countryCode, proxyUrls) {
+    _validateGroupsStructure(groups) {
         for (const group of groups) {
             if (!APIFY_PROXY_VALUE_REGEX.test(group)) this._throwInvalidProxyValueError(group);
         }
-        if (countryCode) {
-            if (!COUNTRY_CODE_REGEX.test(countryCode)) this._throwInvalidCountryCode(countryCode);
-        }
-        if (proxyUrls) {
-            if (!proxyUrls.length) this._throwproxyUrlsIsEmpty();
-            if (((groups && groups.length) || countryCode)) this._throwCannotCombineCustomWithApify();
-            proxyUrls.forEach((customUrl) => {
-                try {
-                    // eslint-disable-next-line no-new
-                    new URL(customUrl);
-                } catch (err) {
-                    this._throwInvalidCustomUrlForm(customUrl);
-                }
-            });
-        }
+    }
+
+    /**
+     * Validates countryCode option
+     * @param {string} countryCode
+     * @ignore
+     */
+    _validateCountryCode(countryCode) {
+        if (!COUNTRY_CODE_REGEX.test(countryCode)) this._throwInvalidCountryCode(countryCode);
+    }
+
+    /**
+     * Validates the structure of all URLs from proxyUrls option
+     * @param {string[]} proxyUrls
+     * @ignore
+     */
+    _validateProxyUrls(proxyUrls) {
+        if (!proxyUrls.length) this._throwProxyUrlsIsEmpty();
+        proxyUrls.forEach((customUrl) => {
+            try {
+                // eslint-disable-next-line no-new
+                new URL(customUrl);
+            } catch (err) {
+                this._throwInvalidCustomUrl(customUrl);
+            }
+        });
     }
 
     /**
@@ -392,7 +414,7 @@ export class ProxyConfiguration {
      * @ignore
      */
     _throwNewUrlFunctionInvalidReturn(url) {
-        throw new Error(`The returned value "${url}" of provided "options.newUrlFunction" is not valid URL.`);
+        throw new Error(`The return value "${url}" of provided "options.newUrlFunction" is not a valid URL.`);
     }
 
     /**
@@ -425,7 +447,7 @@ export class ProxyConfiguration {
      * Throws custom URLs is provided but empty
      * @ignore
      */
-    _throwproxyUrlsIsEmpty() {
+    _throwProxyUrlsIsEmpty() {
         throw new Error('Parameter "options.proxyUrls" of type Array must not be empty!');
     }
 
@@ -435,7 +457,7 @@ export class ProxyConfiguration {
      */
     _throwCannotCombineCustomWithApify() {
         throw new Error('Cannot combine custom proxies with Apify Proxy!'
-            + 'It is not allowed to set "options.proxyUrls" combined with '
+            + 'It is not allowed to set "options.proxyUrls" or "options.newUrlFunction" combined with '
             + '"options.groups" or "options.apifyProxyGroups" and "options.countryCode" or "options.apifyProxyCountry".');
     }
 
@@ -444,8 +466,8 @@ export class ProxyConfiguration {
      * @param {string} url
      * @ignore
      */
-    _throwInvalidCustomUrlForm(url) {
-        throw new Error(`The provided Proxy URL "${url}" is not valid. Please use URL in a form which is compatible with the Node.js URL.`);
+    _throwInvalidCustomUrl(url) {
+        throw new Error(`The provided proxy URL "${url}" is not a valid URL.`);
     }
 }
 
@@ -471,12 +493,12 @@ export class ProxyConfiguration {
  *   // ...
  *   proxyConfiguration,
  *   handlePageFunction: ({ proxyInfo }) => {
- *       const usedProxyUrl = proxyInfo.url; // Getting the Proxy URL
+ *       const usedProxyUrl = proxyInfo.url; // Getting the proxy URL
  *   }
  * })
  *
  * ```
-* @param {ProxyConfigurationOptions} proxyConfigurationOptions
+* @param {ProxyConfigurationOptions} [proxyConfigurationOptions]
 * @returns {Promise<ProxyConfiguration>}
 * @memberof module:Apify
 * @name createProxyConfiguration

--- a/src/puppeteer_pool.js
+++ b/src/puppeteer_pool.js
@@ -63,9 +63,6 @@ class PuppeteerInstance {
 
             if (this.proxyConfiguration) {
                 this.proxyInfo = this.proxyConfiguration.newProxyInfo(this.session ? this.session.id : undefined);
-                if (this.launchPuppeteerOptions && this.launchPuppeteerOptions.proxyUrl) {
-                    this.proxyInfo.url = this.launchPuppeteerOptions.proxyUrl;
-                }
             }
             const proxyUrl = this.proxyInfo ? this.proxyInfo.url : null;
             resolve(this.launchPuppeteerFunction({ proxyUrl }));
@@ -224,7 +221,6 @@ class PuppeteerPool {
         checkParamOrThrow(useLiveView, 'options.useLiveView', 'Maybe Boolean');
         checkParamOrThrow(sessionPool, 'options.sessionPool', 'Maybe Object');
         checkParamOrThrow(proxyConfiguration, 'options.sessionPool', 'Maybe Object');
-
 
         // Config.
         this.sessionPool = sessionPool;

--- a/src/puppeteer_pool.js
+++ b/src/puppeteer_pool.js
@@ -221,6 +221,11 @@ class PuppeteerPool {
         checkParamOrThrow(sessionPool, 'options.sessionPool', 'Maybe Object');
         checkParamOrThrow(proxyConfiguration, 'options.sessionPool', 'Maybe Object');
 
+        if (proxyConfiguration && (launchPuppeteerOptions && launchPuppeteerOptions.proxyUrl)) {
+            throw new Error('It is not possible to combine "options.proxyConfiguration" together with '
+                + 'custom "proxyUrl" option from "options.launchPuppeteerOptions".');
+        }
+
         // Config.
         this.sessionPool = sessionPool;
         this.reusePages = reusePages;

--- a/src/puppeteer_pool.js
+++ b/src/puppeteer_pool.js
@@ -29,13 +29,12 @@ const DISK_CACHE_DIR = path.join(os.tmpdir(), 'puppeteer_disk_cache-');
  *
  * @ignore
  */
-class PuppeteerInstance {
+class PuppeteerInstance { // TODO: this is in progress and it will be refactored later
     constructor(options) {
         const {
             id,
             sessionPool,
             proxyConfiguration,
-            launchPuppeteerOptions,
             launchPuppeteerFunction,
         } = options;
 
@@ -51,7 +50,6 @@ class PuppeteerInstance {
         this.recycleDiskCacheDir = null;
         this.sessionPool = sessionPool;
         this.proxyConfiguration = proxyConfiguration;
-        this.launchPuppeteerOptions = launchPuppeteerOptions;
         this.launchPuppeteerFunction = launchPuppeteerFunction;
     }
 
@@ -126,8 +124,9 @@ class PuppeteerInstance {
  * @property {SessionPool} [sessionPool]
  *   A pool of Session instances.
  * @property {ProxyConfiguration} [proxyConfiguration]
- *   If set, `PuppeteerPool` will be configured to use
- *   [Apify Proxy](https://my.apify.com/proxy) for all connections.
+ *   If set, `PuppeteerPool` will be configured for all connections to use
+ *   [Apify Proxy](https://my.apify.com/proxy) or your own Proxy URLs provided and rotated according to the configuration.
+ *   For more information, see the [documentation](https://docs.apify.com/proxy).
  */
 
 /**
@@ -785,8 +784,9 @@ class PuppeteerPool {
      *
      * @param {Page} page
      * @return {PuppeteerInstance}
+     * @ignore
      */
-    getBrowserInstance(page) {
+    _getBrowserInstance(page) {
         const browser = page.browser();
         return this.browsersToInstancesMap.get(browser);
     }

--- a/src/puppeteer_pool.js
+++ b/src/puppeteer_pool.js
@@ -10,15 +10,12 @@ import defaultLog from './utils_log';
 import { addTimeoutToPromise } from './utils';
 import LiveViewServer from './live_view/live_view_server';
 import EVENTS from './session_pool/events';
-
 // TYPE IMPORTS
 /* eslint-disable no-unused-vars,import/named,import/order */
-import { Page, Browser } from 'puppeteer';
+import { Browser, Page } from 'puppeteer';
 import { launchPuppeteer, LaunchPuppeteerOptions } from './puppeteer';
 import { SessionPool } from './session_pool/session_pool';
 /* eslint-enable no-unused-vars */
-
-export const BROWSER_SESSION_KEY_NAME = 'APIFY_SESSION';
 
 const PROCESS_KILL_TIMEOUT_MILLIS = 5000;
 const PAGE_CLOSE_KILL_TIMEOUT_MILLIS = 1000;
@@ -33,15 +30,46 @@ const DISK_CACHE_DIR = path.join(os.tmpdir(), 'puppeteer_disk_cache-');
  * @ignore
  */
 class PuppeteerInstance {
-    constructor(id, browserPromise) {
+    constructor(options) {
+        const {
+            id,
+            sessionPool,
+            proxyConfiguration,
+            launchPuppeteerOptions,
+            launchPuppeteerFunction,
+        } = options;
+
         this.id = id;
+        this.proxyInfo = null;
+        this.session = null;
         this.activePages = 0;
         this.totalPages = 0;
-        this.browserPromise = browserPromise;
+        this.browserPromise = null;
         this.lastPageOpenedAt = Date.now();
         this.killed = false;
         this.childProcess = null;
         this.recycleDiskCacheDir = null;
+        this.sessionPool = sessionPool;
+        this.proxyConfiguration = proxyConfiguration;
+        this.launchPuppeteerOptions = launchPuppeteerOptions;
+        this.launchPuppeteerFunction = launchPuppeteerFunction;
+    }
+
+    async launch() {
+        this.browserPromise = new Promise(async (resolve) => {
+            if (this.sessionPool) {
+                this.session = await this.sessionPool.getSession();
+            }
+
+            if (this.proxyConfiguration) {
+                this.proxyInfo = this.proxyConfiguration.newProxyInfo(this.session ? this.session.id : undefined);
+                if (this.launchPuppeteerOptions && this.launchPuppeteerOptions.proxyUrl) {
+                    this.proxyInfo.url = this.launchPuppeteerOptions.proxyUrl;
+                }
+            }
+            const proxyUrl = this.proxyInfo ? this.proxyInfo.url : null;
+            resolve(this.launchPuppeteerFunction({ proxyUrl }));
+        });
     }
 }
 
@@ -100,11 +128,6 @@ class PuppeteerInstance {
  *   that they will not share cookies or cache and their resources will not be throttled by one another.
  * @property {SessionPool} [sessionPool]
  *   A pool of Session instances.
- * @property {string[]} [proxyUrls]
- *   An array of custom proxy URLs to be used by the `PuppeteerPool` instance.
- *   The provided custom proxies' order will be randomized and the resulting list rotated.
- *   Custom proxies are not compatible with Apify Proxy and an attempt to use both
- *   configuration options will cause an error to be thrown on startup.
  * @property {ProxyConfiguration} [proxyConfiguration]
  *   If set, `PuppeteerPool` will be configured to use
  *   [Apify Proxy](https://my.apify.com/proxy) for all connections.
@@ -166,7 +189,6 @@ class PuppeteerPool {
             launchPuppeteerOptions,
             recycleDiskCache = false,
             useIncognitoPages = false,
-            proxyUrls,
             proxyConfiguration,
             useLiveView = false,
             sessionPool,
@@ -198,13 +220,10 @@ class PuppeteerPool {
         checkParamOrThrow(launchPuppeteerOptions, 'options.launchPuppeteerOptions', 'Maybe Object');
         checkParamOrThrow(recycleDiskCache, 'options.recycleDiskCache', 'Maybe Boolean');
         checkParamOrThrow(useIncognitoPages, 'options.useIncognitoPages', 'Maybe Boolean');
-        checkParamOrThrow(proxyUrls, 'options.proxyUrls', 'Maybe Array');
-        // Enforce non-empty proxyUrls array
-        if (proxyUrls && !proxyUrls.length) throw new Error('Parameter "options.proxyUrls" of type Array must not be empty');
-        if (proxyConfiguration && proxyUrls) throw new Error('Cannot combine "options.proxyConfiguration" with "options.proxyUrls"!');
 
         checkParamOrThrow(useLiveView, 'options.useLiveView', 'Maybe Boolean');
         checkParamOrThrow(sessionPool, 'options.sessionPool', 'Maybe Object');
+        checkParamOrThrow(proxyConfiguration, 'options.sessionPool', 'Maybe Object');
 
 
         // Config.
@@ -221,10 +240,10 @@ class PuppeteerPool {
          */
         this.recycledDiskCacheDirs = recycleDiskCache ? new LinkedList() : null;
         this.useIncognitoPages = useIncognitoPages;
-        this.proxyUrls = proxyUrls ? _.shuffle(proxyUrls) : null;
         this.proxyConfiguration = proxyConfiguration;
         this.liveViewServer = useLiveView ? new LiveViewServer() : null;
-        this.launchPuppeteerFunction = async () => {
+        this.launchPuppeteerOptions = launchPuppeteerOptions;
+        this.launchPuppeteerFunction = async ({ proxyUrl }) => {
             // Do not modify passed launchPuppeteerOptions!
             const opts = _.clone(launchPuppeteerOptions) || {};
             opts.args = _.clone(opts.args || []);
@@ -238,21 +257,11 @@ class PuppeteerPool {
                 opts.args.push(`--disk-cache-dir=${diskCacheDir}`);
             }
 
-            // Rotate custom proxyUrls.
-            if (this.proxyUrls) {
-                opts.proxyUrl = this.proxyUrls[this.lastUsedProxyUrlIndex++ % this.proxyUrls.length];
-            }
-
             // Set timeout for browser launch.
             if (opts.timeout == null) opts.timeout = this.puppeteerOperationTimeoutMillis;
 
-            let session;
-            if (sessionPool) {
-                session = await sessionPool.getSession();
-            }
-
             if (proxyConfiguration) {
-                opts.proxyUrl = proxyConfiguration.getUrl(session ? session.id : undefined);
+                opts.proxyUrl = proxyUrl;
             }
 
             const browser = await launchPuppeteerFunction(opts);
@@ -261,8 +270,6 @@ class PuppeteerPool {
                 throw new Error("The custom 'launchPuppeteerFunction' passed to PuppeteerPool must return a promise resolving to Puppeteer's Browser instance.");
             }
             browser.recycleDiskCacheDir = diskCacheDir;
-
-            if (session) browser[BROWSER_SESSION_KEY_NAME] = session;
 
             return browser;
         };
@@ -283,6 +290,7 @@ class PuppeteerPool {
         // are no references to the stored pages.
         this.closedPages = new WeakSet();
         this.pagesToInstancesMap = new WeakMap();
+        this.browsersToInstancesMap = new WeakMap();
 
         this.liveViewSnapshotsInProgress = new WeakMap();
 
@@ -305,33 +313,34 @@ class PuppeteerPool {
         const id = this.browserCounter++;
         this.log.debug('Launching new browser', { id });
 
-        const browserPromise = this.launchPuppeteerFunction();
-
-        const instance = new PuppeteerInstance(id, browserPromise);
+        const instance = new PuppeteerInstance({
+            id,
+            sessionPool: this.sessionPool,
+            proxyConfiguration: this.proxyConfiguration,
+            launchPuppeteerOptions: this.launchPuppeteerOptions,
+            launchPuppeteerFunction: this.launchPuppeteerFunction,
+        });
         this.activeInstances[id] = instance;
 
         // Handle the async stuff elsewhere.
-        this._initBrowser(browserPromise, instance);
+        this._initBrowser(instance);
 
         return instance;
     }
 
     /**
      * Takes care of async processes in PuppeteerInstance construction with a Browser.
-     * @param {Promise<Browser>} browserPromise
      * @param {PuppeteerInstance} instance
      * @returns {Promise<void>}
      * @ignore
      */
-    async _initBrowser(browserPromise, instance) {
+    async _initBrowser(instance) {
         const { id } = instance;
         let browser;
         try {
-            browser = await browserPromise;
-
-            if (this.sessionPool) {
-                instance.session = browser[BROWSER_SESSION_KEY_NAME];
-            }
+            await instance.launch();
+            browser = await instance.browserPromise;
+            this.browsersToInstancesMap.set(browser, instance);
         } catch (err) {
             this.log.exception(err, 'Browser launch failed', { id });
             delete this.activeInstances[id];
@@ -772,6 +781,18 @@ class PuppeteerPool {
                 this._killInstance(instance);
             }, PAGE_CLOSE_KILL_TIMEOUT_MILLIS);
         }
+    }
+
+
+    /**
+     * Gets Puppeteer Instance by the page.
+     *
+     * @param {Page} page
+     * @return {PuppeteerInstance}
+     */
+    getBrowserInstance(page) {
+        const browser = page.browser();
+        return this.browsersToInstancesMap.get(browser);
     }
 }
 

--- a/test/crawlers/cheerio_crawler.test.js
+++ b/test/crawlers/cheerio_crawler.test.js
@@ -655,12 +655,7 @@ describe('CheerioCrawler', () => {
         test('should work with proxyUrls configuration', async () => {
             process.env[ENV_VARS.PROXY_PASSWORD] = 'abc123';
             const proxies = [];
-            const status = { connected: true };
-            const fakeCall = async () => {
-                return { body: status };
-            };
 
-            const stub = sinon.stub(utilsRequest, 'requestAsBrowser').callsFake(fakeCall);
             const proxyConfiguration = await Apify.createProxyConfiguration({
                 proxyUrls: ['http://proxy.com:1111', 'http://proxy.com:2222', 'http://proxy.com:3333'],
             });
@@ -689,19 +684,13 @@ describe('CheerioCrawler', () => {
             expect(proxies[3]).toEqual(proxyUrls[0]);
 
             delete process.env[ENV_VARS.PROXY_PASSWORD];
-            stub.restore();
         });
 
         test('should correctly pass the url to proxyInfo with proxyUrls configuration and sessionPool', async () => {
             process.env[ENV_VARS.PROXY_PASSWORD] = 'abc123';
             const proxies = [];
             const proxyChecks = [];
-            const status = { connected: true };
-            const fakeCall = async () => {
-                return { body: status };
-            };
 
-            const stub = sinon.stub(utilsRequest, 'requestAsBrowser').callsFake(fakeCall);
             const proxyConfiguration = await Apify.createProxyConfiguration({
                 proxyUrls: ['http://proxy.com:1111', 'http://proxy.com:2222', 'http://proxy.com:3333'],
             });
@@ -730,7 +719,6 @@ describe('CheerioCrawler', () => {
             expect(proxies[3]).toEqual(proxyChecks[3].url);
 
             delete process.env[ENV_VARS.PROXY_PASSWORD];
-            stub.restore();
         });
     });
 

--- a/test/crawlers/puppeteer_crawler.test.js
+++ b/test/crawlers/puppeteer_crawler.test.js
@@ -255,12 +255,7 @@ describe('PuppeteerCrawler', () => {
 
         test('browser should launch with rotated custom proxy', async () => {
             process.env[ENV_VARS.PROXY_PASSWORD] = 'abc123';
-            const status = { connected: true };
-            const fakeCall = async () => {
-                return { body: status };
-            };
 
-            const stub = sinon.stub(utilsRequest, 'requestAsBrowser').callsFake(fakeCall);
             const proxyConfiguration = await Apify.createProxyConfiguration({
                 proxyUrls: ['http://proxy.com:1111', 'http://proxy.com:2222', 'http://proxy.com:3333'],
             });
@@ -293,17 +288,11 @@ describe('PuppeteerCrawler', () => {
             expect(browserProxies[3]).toEqual(proxiesToUse[0]);
 
             delete process.env[ENV_VARS.PROXY_PASSWORD];
-            stub.restore();
         });
 
         test('should throw on proxyConfiguration together with proxyUrl from launchPuppeteerOptions', async () => {
             process.env[ENV_VARS.PROXY_PASSWORD] = 'abc123';
-            const status = { connected: true };
-            const fakeCall = async () => {
-                return { body: status };
-            };
 
-            const stub = sinon.stub(utilsRequest, 'requestAsBrowser').callsFake(fakeCall);
             const proxyConfiguration = await Apify.createProxyConfiguration({
                 proxyUrls: ['http://proxy.com:1111', 'http://proxy.com:2222', 'http://proxy.com:3333'],
             });
@@ -325,7 +314,6 @@ describe('PuppeteerCrawler', () => {
             }
 
             delete process.env[ENV_VARS.PROXY_PASSWORD];
-            stub.restore();
         });
     });
 });

--- a/test/crawlers/puppeteer_crawler.test.js
+++ b/test/crawlers/puppeteer_crawler.test.js
@@ -191,7 +191,7 @@ describe('PuppeteerCrawler', () => {
 
             const stub = sinon.stub(utilsRequest, 'requestAsBrowser').callsFake(fakeCall);
             const proxyConfiguration = await Apify.createProxyConfiguration();
-            const generatedProxyUrl = proxyConfiguration.getUrl();
+            const generatedProxyUrl = proxyConfiguration.newUrl();
             let browserProxy;
             const launchPuppeteerFunction = async (opts) => {
                 browserProxy = opts.proxyUrl;
@@ -244,10 +244,53 @@ describe('PuppeteerCrawler', () => {
 
             await puppeteerCrawler.run();
 
-            expect(proxies[0]).toEqual(proxyConfiguration.getInfo(sessions[0].id));
-            expect(proxies[1]).toEqual(proxyConfiguration.getInfo(sessions[1].id));
-            expect(proxies[2]).toEqual(proxyConfiguration.getInfo(sessions[2].id));
-            expect(proxies[3]).toEqual(proxyConfiguration.getInfo(sessions[3].id));
+            expect(proxies[0].sessionId).toEqual(sessions[0].id);
+            expect(proxies[1].sessionId).toEqual(sessions[1].id);
+            expect(proxies[2].sessionId).toEqual(sessions[2].id);
+            expect(proxies[3].sessionId).toEqual(sessions[3].id);
+
+            delete process.env[ENV_VARS.PROXY_PASSWORD];
+            stub.restore();
+        });
+
+        test('browser should launch with rotated custom proxy', async () => {
+            process.env[ENV_VARS.PROXY_PASSWORD] = 'abc123';
+            const status = { connected: true };
+            const fakeCall = async () => {
+                return { body: status };
+            };
+
+            const stub = sinon.stub(utilsRequest, 'requestAsBrowser').callsFake(fakeCall);
+            const proxyConfiguration = await Apify.createProxyConfiguration({
+                proxyUrls: ['http://proxy.com:1111', 'http://proxy.com:2222', 'http://proxy.com:3333'],
+            });
+
+            const browserProxies = [];
+            const launchPuppeteerFunction = async (opts) => {
+                browserProxies.push(opts.proxyUrl);
+                const browser = await Apify.launchPuppeteer(opts);
+
+                return browser;
+            };
+
+            const puppeteerCrawler = new Apify.PuppeteerCrawler({
+                requestList,
+                handlePageFunction: async () => {},
+                gotoFunction: async () => {},
+                launchPuppeteerFunction,
+                puppeteerPoolOptions: {
+                    retireInstanceAfterRequestCount: 1,
+                },
+                proxyConfiguration,
+            });
+
+            await puppeteerCrawler.run();
+
+            const proxiesToUse = proxyConfiguration.proxyUrls;
+            expect(browserProxies[0]).toEqual(proxiesToUse[0]);
+            expect(browserProxies[1]).toEqual(proxiesToUse[1]);
+            expect(browserProxies[2]).toEqual(proxiesToUse[2]);
+            expect(browserProxies[3]).toEqual(proxiesToUse[0]);
 
             delete process.env[ENV_VARS.PROXY_PASSWORD];
             stub.restore();

--- a/test/proxy_configuration.test.js
+++ b/test/proxy_configuration.test.js
@@ -146,11 +146,11 @@ describe('ProxyConfiguration', () => {
             proxyConfiguration.newUrl();
             throw new Error('wrong error');
         } catch (err) {
-            expect(err.message).toMatch('The returned value "http://proxy.com:1111*invalid_url"');
+            expect(err.message).toMatch('The return value "http://proxy.com:1111*invalid_url"');
         }
     });
 
-    test('should newUrlFunction correctly generate URLs', async () => {
+    test('newUrlFunction should correctly generate URLs', async () => {
         const customUrls = ['http://proxy.com:1111', 'http://proxy.com:2222', 'http://proxy.com:3333',
             'http://proxy.com:4444', 'http://proxy.com:5555', 'http://proxy.com:6666'];
         const newUrlFunction = () => {
@@ -257,7 +257,7 @@ describe('ProxyConfiguration', () => {
                 });
                 throw new Error('wrong error');
             } catch (err) {
-                expect(err.message).toMatch('The provided Proxy URL "http://proxy.com:1111*invalid_url" is not valid.');
+                expect(err.message).toEqual('The provided proxy URL "http://proxy.com:1111*invalid_url" is not a valid URL.');
             }
         });
     });

--- a/test/proxy_configuration.test.js
+++ b/test/proxy_configuration.test.js
@@ -225,15 +225,47 @@ describe('ProxyConfiguration', () => {
         });
 
         test('should throw cannot combine custom proxies with Apify Proxy', async () => {
+            const proxyUrls = ['http://proxy.com:1111', 'http://proxy.com:2222', 'http://proxy.com:3333'];
+            const newUrlFunction = () => {
+                return proxyUrls[Math.floor(Math.random() * proxyUrls.length)];
+            };
             try {
                 // eslint-disable-next-line no-unused-vars
                 const proxyConfiguration = new ProxyConfiguration({
                     groups: ['GROUP1'],
-                    proxyUrls: ['http://proxy.com:1111', 'http://proxy.com:2222', 'http://proxy.com:3333'],
+                    proxyUrls,
                 });
                 throw new Error('wrong error');
             } catch (err) {
                 expect(err.message).toMatch('Cannot combine custom proxies with Apify Proxy!');
+            }
+
+            try {
+                // eslint-disable-next-line no-unused-vars
+                const proxyConfiguration = new ProxyConfiguration({
+                    groups: ['GROUP1'],
+                    newUrlFunction,
+                });
+                throw new Error('wrong error');
+            } catch (err) {
+                expect(err.message).toMatch('Cannot combine custom proxies with Apify Proxy!');
+            }
+        });
+
+        test('should throw cannot combine custom methods', async () => {
+            const proxyUrls = ['http://proxy.com:1111', 'http://proxy.com:2222', 'http://proxy.com:3333'];
+            const newUrlFunction = () => {
+                return proxyUrls[Math.floor(Math.random() * proxyUrls.length)];
+            };
+            try {
+                // eslint-disable-next-line no-unused-vars
+                const proxyConfiguration = new ProxyConfiguration({
+                    proxyUrls,
+                    newUrlFunction,
+                });
+                throw new Error('wrong error');
+            } catch (err) {
+                expect(err.message).toMatch('Cannot combine custom proxies "options.proxyUrls"');
             }
         });
 

--- a/test/proxy_configuration.test.js
+++ b/test/proxy_configuration.test.js
@@ -34,13 +34,13 @@ describe('ProxyConfiguration', () => {
         expect(proxyConfiguration.port).toBe(port);
     });
 
-    test('getUrl() should return proxy URL', () => {
+    test('newUrl() should return proxy URL', () => {
         const proxyConfiguration = new ProxyConfiguration(basicOpts);
 
-        expect(proxyConfiguration.getUrl(sessionId)).toBe(basicOptsProxyUrl);
+        expect(proxyConfiguration.newUrl(sessionId)).toBe(basicOptsProxyUrl);
     });
 
-    test('getInfo() should return ProxyInfo object', () => {
+    test('newProxyInfo() should return ProxyInfo object', () => {
         const proxyConfiguration = new ProxyConfiguration(basicOpts);
         const url = basicOptsProxyUrl;
 
@@ -53,7 +53,7 @@ describe('ProxyConfiguration', () => {
             hostname,
             port,
         };
-        expect(proxyConfiguration.getInfo(sessionId)).toStrictEqual(proxyInfo);
+        expect(proxyConfiguration.newProxyInfo(sessionId)).toStrictEqual(proxyInfo);
     });
 
     test('actor UI input schema should work', () => {
@@ -116,109 +116,150 @@ describe('ProxyConfiguration', () => {
         expect(() => new ProxyConfiguration({ countryCode: 1111 })).toThrow();
     });
 
-    test('getUrl() should throw invalid session argument', () => {
+    test('newUrl() should throw invalid session argument', () => {
         const proxyConfiguration = new ProxyConfiguration();
 
-        expect(() => proxyConfiguration.getUrl('a-b')).toThrowError();
-        expect(() => proxyConfiguration.getUrl('a$b')).toThrowError();
-        expect(() => proxyConfiguration.getUrl({})).toThrowError();
-        expect(() => proxyConfiguration.getUrl(new Date())).toThrowError();
+        expect(() => proxyConfiguration.newUrl('a-b')).toThrowError();
+        expect(() => proxyConfiguration.newUrl('a$b')).toThrowError();
+        expect(() => proxyConfiguration.newUrl({})).toThrowError();
+        expect(() => proxyConfiguration.newUrl(new Date())).toThrowError();
 
-        expect(() => proxyConfiguration.getUrl('a_b')).not.toThrowError();
-        expect(() => proxyConfiguration.getUrl('0.34252352')).not.toThrowError();
-        expect(() => proxyConfiguration.getUrl('aaa~BBB')).not.toThrowError();
-        expect(() => proxyConfiguration.getUrl('a_1_b')).not.toThrowError();
-        expect(() => proxyConfiguration.getUrl('a_2')).not.toThrowError();
-        expect(() => proxyConfiguration.getUrl('a')).not.toThrowError();
-        expect(() => proxyConfiguration.getUrl('1')).not.toThrowError();
+        expect(() => proxyConfiguration.newUrl('a_b')).not.toThrowError();
+        expect(() => proxyConfiguration.newUrl('0.34252352')).not.toThrowError();
+        expect(() => proxyConfiguration.newUrl('aaa~BBB')).not.toThrowError();
+        expect(() => proxyConfiguration.newUrl('a_1_b')).not.toThrowError();
+        expect(() => proxyConfiguration.newUrl('a_2')).not.toThrowError();
+        expect(() => proxyConfiguration.newUrl('a')).not.toThrowError();
+        expect(() => proxyConfiguration.newUrl('1')).not.toThrowError();
+        expect(() => proxyConfiguration.newUrl(123456)).not.toThrowError();
     });
 
-    test('should throw cannot combine custom proxies with Apify Proxy', async () => {
+    test('should throw invalid newUrlFunction return value', async () => {
+        const newUrlFunction = () => {
+            return 'http://proxy.com:1111*invalid_url';
+        };
+        const proxyConfiguration = new ProxyConfiguration({
+            newUrlFunction,
+        });
         try {
             // eslint-disable-next-line no-unused-vars
-            const proxyConfiguration = new ProxyConfiguration({
-                groups: ['GROUP1'],
-                customUrls: ['http://proxy.com:1111', 'http://proxy.com:2222', 'http://proxy.com:3333'],
-            });
+            proxyConfiguration.newUrl();
             throw new Error('wrong error');
         } catch (err) {
-            expect(err.message).toMatch('Cannot combine custom proxies with Apify Proxy!');
+            expect(err.message).toMatch('The returned value "http://proxy.com:1111*invalid_url"');
         }
     });
 
-    test('should throw customUrls array is empty', async () => {
-        try {
-            // eslint-disable-next-line no-unused-vars
+    test('should newUrlFunction correctly generate URLs', async () => {
+        const customUrls = ['http://proxy.com:1111', 'http://proxy.com:2222', 'http://proxy.com:3333',
+            'http://proxy.com:4444', 'http://proxy.com:5555', 'http://proxy.com:6666'];
+        const newUrlFunction = () => {
+            return customUrls.pop();
+        };
+        const proxyConfiguration = new ProxyConfiguration({
+            newUrlFunction,
+        });
+
+        // through newUrl()
+        expect(proxyConfiguration.newUrl()).toEqual('http://proxy.com:6666');
+        expect(proxyConfiguration.newUrl()).toEqual('http://proxy.com:5555');
+        expect(proxyConfiguration.newUrl()).toEqual('http://proxy.com:4444');
+
+        // through newProxyInfo()
+        expect(proxyConfiguration.newProxyInfo().url).toEqual('http://proxy.com:3333');
+        expect(proxyConfiguration.newProxyInfo().url).toEqual('http://proxy.com:2222');
+        expect(proxyConfiguration.newProxyInfo().url).toEqual('http://proxy.com:1111');
+    });
+
+    describe('With proxyUrls options', () => {
+        test('should rotate custom URLs correctly', async () => {
             const proxyConfiguration = new ProxyConfiguration({
-                customUrls: [],
+                proxyUrls: ['http://proxy.com:1111', 'http://proxy.com:2222', 'http://proxy.com:3333'],
             });
-            throw new Error('wrong error');
-        } catch (err) {
-            expect(err.message).toMatch('must not be empty');
-        }
-    });
 
-    test('should throw invalid custom URL form', async () => {
-        try {
-            // eslint-disable-next-line no-unused-vars
+            const { proxyUrls } = proxyConfiguration;
+            expect(proxyConfiguration.newUrl()).toEqual(proxyUrls[0]);
+            expect(proxyConfiguration.newUrl()).toEqual(proxyUrls[1]);
+            expect(proxyConfiguration.newUrl()).toEqual(proxyUrls[2]);
+            expect(proxyConfiguration.newUrl()).toEqual(proxyUrls[0]);
+            expect(proxyConfiguration.newUrl()).toEqual(proxyUrls[1]);
+            expect(proxyConfiguration.newUrl()).toEqual(proxyUrls[2]);
+        });
+
+        test('newProxyInfo() should return correctly rotated URL', async () => {
             const proxyConfiguration = new ProxyConfiguration({
-                customUrls: ['http://proxy.com:1111*invalid_url'],
+                proxyUrls: ['http://proxy.com:1111', 'http://proxy.com:2222', 'http://proxy.com:3333'],
             });
-            throw new Error('wrong error');
-        } catch (err) {
-            expect(err.message).toMatch('The provided Proxy URL "http://proxy.com:1111*invalid_url" is not valid.');
-        }
-    });
 
-    test('should rotate custom URLs correctly', async () => {
-        const proxyConfiguration = new ProxyConfiguration({
-            customUrls: ['http://proxy.com:1111', 'http://proxy.com:2222', 'http://proxy.com:3333'],
+            const { proxyUrls } = proxyConfiguration;
+            expect(proxyConfiguration.newProxyInfo().url).toEqual(proxyUrls[0]);
+            expect(proxyConfiguration.newProxyInfo().url).toEqual(proxyUrls[1]);
+            expect(proxyConfiguration.newProxyInfo().url).toEqual(proxyUrls[2]);
+            expect(proxyConfiguration.newProxyInfo().url).toEqual(proxyUrls[0]);
+            expect(proxyConfiguration.newProxyInfo().url).toEqual(proxyUrls[1]);
+            expect(proxyConfiguration.newProxyInfo().url).toEqual(proxyUrls[2]);
         });
 
-        const proxyUrls = proxyConfiguration.customUrls;
-        expect(proxyConfiguration.getUrl()).toEqual(proxyUrls[0]);
-        expect(proxyConfiguration.getUrl()).toEqual(proxyUrls[1]);
-        expect(proxyConfiguration.getUrl()).toEqual(proxyUrls[2]);
-        expect(proxyConfiguration.getUrl()).toEqual(proxyUrls[0]);
-        expect(proxyConfiguration.getUrl()).toEqual(proxyUrls[1]);
-        expect(proxyConfiguration.getUrl()).toEqual(proxyUrls[2]);
-    });
+        test('should rotate custom URLs with sessions correctly', async () => {
+            const sessions = ['sesssion_01', 'sesssion_02', 'sesssion_03', 'sesssion_04', 'sesssion_05', 'sesssion_06'];
+            const proxyConfiguration = new ProxyConfiguration({
+                proxyUrls: ['http://proxy.com:1111', 'http://proxy.com:2222', 'http://proxy.com:3333'],
+            });
 
-    test('getInfo() should return currently used URL', async () => {
-        const proxyConfiguration = new ProxyConfiguration({
-            customUrls: ['http://proxy.com:1111', 'http://proxy.com:2222', 'http://proxy.com:3333'],
+            const { proxyUrls } = proxyConfiguration;
+            // should use same proxy URL
+            expect(proxyConfiguration.newUrl(sessions[0])).toEqual(proxyUrls[0]);
+            expect(proxyConfiguration.newUrl(sessions[0])).toEqual(proxyUrls[0]);
+            expect(proxyConfiguration.newUrl(sessions[0])).toEqual(proxyUrls[0]);
+
+            // should rotate different proxies
+            expect(proxyConfiguration.newUrl(sessions[1])).toEqual(proxyUrls[1]);
+            expect(proxyConfiguration.newUrl(sessions[2])).toEqual(proxyUrls[2]);
+            expect(proxyConfiguration.newUrl(sessions[3])).toEqual(proxyUrls[0]);
+            expect(proxyConfiguration.newUrl(sessions[4])).toEqual(proxyUrls[1]);
+            expect(proxyConfiguration.newUrl(sessions[5])).toEqual(proxyUrls[2]);
+
+            // should remember already used session
+            expect(proxyConfiguration.newUrl(sessions[1])).toEqual(proxyUrls[1]);
+            expect(proxyConfiguration.newUrl(sessions[3])).toEqual(proxyUrls[0]);
         });
 
-        expect(proxyConfiguration.getUrl()).toEqual(proxyConfiguration.getInfo().url);
-        expect(proxyConfiguration.getUrl()).toEqual(proxyConfiguration.getInfo().url);
-        expect(proxyConfiguration.getUrl()).toEqual(proxyConfiguration.getInfo().url);
-        expect(proxyConfiguration.getUrl()).toEqual(proxyConfiguration.getInfo().url);
-        expect(proxyConfiguration.getUrl()).toEqual(proxyConfiguration.getInfo().url);
-        expect(proxyConfiguration.getUrl()).toEqual(proxyConfiguration.getInfo().url);
-    });
-
-    test('should rotate custom URLs with sessions correctly', async () => {
-        const sessions = ['sesssion_01', 'sesssion_02', 'sesssion_03', 'sesssion_04', 'sesssion_05', 'sesssion_06'];
-        const proxyConfiguration = new ProxyConfiguration({
-            customUrls: ['http://proxy.com:1111', 'http://proxy.com:2222', 'http://proxy.com:3333'],
+        test('should throw cannot combine custom proxies with Apify Proxy', async () => {
+            try {
+                // eslint-disable-next-line no-unused-vars
+                const proxyConfiguration = new ProxyConfiguration({
+                    groups: ['GROUP1'],
+                    proxyUrls: ['http://proxy.com:1111', 'http://proxy.com:2222', 'http://proxy.com:3333'],
+                });
+                throw new Error('wrong error');
+            } catch (err) {
+                expect(err.message).toMatch('Cannot combine custom proxies with Apify Proxy!');
+            }
         });
 
-        const proxyUrls = proxyConfiguration.customUrls;
-        // should use same proxy URL
-        expect(proxyConfiguration.getUrl(sessions[0])).toEqual(proxyUrls[0]);
-        expect(proxyConfiguration.getUrl(sessions[0])).toEqual(proxyUrls[0]);
-        expect(proxyConfiguration.getUrl(sessions[0])).toEqual(proxyUrls[0]);
+        test('should throw proxyUrls array is empty', async () => {
+            try {
+                // eslint-disable-next-line no-unused-vars
+                const proxyConfiguration = new ProxyConfiguration({
+                    proxyUrls: [],
+                });
+                throw new Error('wrong error');
+            } catch (err) {
+                expect(err.message).toMatch('must not be empty');
+            }
+        });
 
-        // should rotate different proxies
-        expect(proxyConfiguration.getUrl(sessions[1])).toEqual(proxyUrls[1]);
-        expect(proxyConfiguration.getUrl(sessions[2])).toEqual(proxyUrls[2]);
-        expect(proxyConfiguration.getUrl(sessions[3])).toEqual(proxyUrls[0]);
-        expect(proxyConfiguration.getUrl(sessions[4])).toEqual(proxyUrls[1]);
-        expect(proxyConfiguration.getUrl(sessions[5])).toEqual(proxyUrls[2]);
-
-        // should remember already used session
-        expect(proxyConfiguration.getUrl(sessions[1])).toEqual(proxyUrls[1]);
-        expect(proxyConfiguration.getUrl(sessions[3])).toEqual(proxyUrls[0]);
+        test('should throw invalid custom URL form', async () => {
+            try {
+                // eslint-disable-next-line no-unused-vars
+                const proxyConfiguration = new ProxyConfiguration({
+                    proxyUrls: ['http://proxy.com:1111*invalid_url'],
+                });
+                throw new Error('wrong error');
+            } catch (err) {
+                expect(err.message).toMatch('The provided Proxy URL "http://proxy.com:1111*invalid_url" is not valid.');
+            }
+        });
     });
 });
 

--- a/test/puppeteer_pool.test.js
+++ b/test/puppeteer_pool.test.js
@@ -547,13 +547,10 @@ describe('PuppeteerPool', () => {
             const page2 = await pool.newPage();
             const page3 = await pool.newPage();
             const page4 = await pool.newPage();
-            // eslint-disable-next-line no-underscore-dangle
+            /* eslint-disable no-underscore-dangle */
             proxyUrls.push(pool._getBrowserInstance(page1).proxyInfo.url);
-            // eslint-disable-next-line no-underscore-dangle
             proxyUrls.push(pool._getBrowserInstance(page2).proxyInfo.url);
-            // eslint-disable-next-line no-underscore-dangle
             proxyUrls.push(pool._getBrowserInstance(page3).proxyInfo.url);
-            // eslint-disable-next-line no-underscore-dangle
             proxyUrls.push(pool._getBrowserInstance(page4).proxyInfo.url);
 
             await pool.destroy();
@@ -597,6 +594,29 @@ describe('PuppeteerPool', () => {
             expect(optionsLog[1].proxyUrl).toEqual(proxies[1]);
             expect(optionsLog[2].proxyUrl).toEqual(proxies[2]);
             expect(optionsLog[3].proxyUrl).toEqual(proxies[0]);
+
+            delete process.env[ENV_VARS.PROXY_PASSWORD];
+        });
+
+        test('should throw on proxyConfiguration together with proxyUrl from launchPuppeteerOptions', async () => {
+            process.env[ENV_VARS.PROXY_PASSWORD] = 'abc123';
+
+            const proxyConfiguration = await Apify.createProxyConfiguration({
+                proxyUrls: ['http://proxy.com:1111', 'http://proxy.com:2222', 'http://proxy.com:3333'],
+            });
+
+            try {
+                // eslint-disable-next-line no-unused-vars
+                const pool = new Apify.PuppeteerPool({
+                    proxyConfiguration,
+                    launchPuppeteerOptions: {
+                        proxyUrl: 'http://proxy.com:1111',
+                    },
+                });
+                throw new Error('wrong error');
+            } catch (err) {
+                expect(err.message).toMatch('It is not possible to combine "options.proxyConfiguration"');
+            }
 
             delete process.env[ENV_VARS.PROXY_PASSWORD];
         });

--- a/test/puppeteer_pool.test.js
+++ b/test/puppeteer_pool.test.js
@@ -547,10 +547,14 @@ describe('PuppeteerPool', () => {
             const page2 = await pool.newPage();
             const page3 = await pool.newPage();
             const page4 = await pool.newPage();
-            proxyUrls.push(pool.getBrowserInstance(page1).proxyInfo.url);
-            proxyUrls.push(pool.getBrowserInstance(page2).proxyInfo.url);
-            proxyUrls.push(pool.getBrowserInstance(page3).proxyInfo.url);
-            proxyUrls.push(pool.getBrowserInstance(page4).proxyInfo.url);
+            // eslint-disable-next-line no-underscore-dangle
+            proxyUrls.push(pool._getBrowserInstance(page1).proxyInfo.url);
+            // eslint-disable-next-line no-underscore-dangle
+            proxyUrls.push(pool._getBrowserInstance(page2).proxyInfo.url);
+            // eslint-disable-next-line no-underscore-dangle
+            proxyUrls.push(pool._getBrowserInstance(page3).proxyInfo.url);
+            // eslint-disable-next-line no-underscore-dangle
+            proxyUrls.push(pool._getBrowserInstance(page4).proxyInfo.url);
 
             await pool.destroy();
 
@@ -566,14 +570,9 @@ describe('PuppeteerPool', () => {
         });
 
         test('supports rotation of custom proxies', async () => {
-            const optionsLog = [];
             process.env[ENV_VARS.PROXY_PASSWORD] = 'abc123';
-            const status = { connected: true };
-            const fakeCall = async () => {
-                return { body: status };
-            };
+            const optionsLog = [];
 
-            const stub = sinon.stub(utilsRequest, 'requestAsBrowser').callsFake(fakeCall);
             const proxyConfiguration = await Apify.createProxyConfiguration({
                 proxyUrls: ['http://proxy.com:1111', 'http://proxy.com:2222', 'http://proxy.com:3333'],
             });
@@ -600,7 +599,6 @@ describe('PuppeteerPool', () => {
             expect(optionsLog[3].proxyUrl).toEqual(proxies[0]);
 
             delete process.env[ENV_VARS.PROXY_PASSWORD];
-            stub.restore();
         });
     });
 
@@ -694,7 +692,8 @@ describe('PuppeteerPool', () => {
             });
             expect(pool.sessionPool.constructor.name).toEqual('SessionPool');
             const page = await pool.newPage();
-            const browserSession = pool.getBrowserInstance(page).session;
+            // eslint-disable-next-line no-underscore-dangle
+            const browserSession = pool._getBrowserInstance(page).session;
 
             expect(browserSession.id).toEqual(sessionPool.sessions[0].id);
             expect(

--- a/test/session_pool/session.test.js
+++ b/test/session_pool/session.test.js
@@ -124,7 +124,7 @@ describe('Session - testing session behaviour ', () => {
         session = new Session({ sessionPool });
         let error;
         try {
-            proxyConfiguration.getUrl(session.id);
+            proxyConfiguration.newUrl(session.id);
         } catch (e) {
             error = e;
         }


### PR DESCRIPTION
-  `proxyConfiguration` supports custom proxies with `proxyUrls` option
-  `newUrlFunction` option allows to generate Proxy URLs dynamically
-  `puppeteerPool` now manages proxy
     -   `session` and `proxyInfo` are set to the `puppeteerInstance`
     -    new `getBrowserInstance()` method to get the right `session` and `proxyInfo`
-   removed `proxyConfiguration` option from `basicCrawler`
-   new way of how `cheerioCrawler` manages the proxy