### PR TITLE
Fix key_value_store path in Getting Started guide

### DIFF
--- a/docs/guides/getting_started.md
+++ b/docs/guides/getting_started.md
@@ -1539,7 +1539,7 @@ and by calling [`Apify.getInput()`](/docs/api/apify#getvalue) you retrieve the v
 Running locally, you need to place an `INPUT.json` file in your default key value store for this to work.
 
 ```
-{PROJECT_FOLDER}/apify_storage/key-value-stores/default/INPUT.json
+{PROJECT_FOLDER}/apify_storage/key_value_stores/default/INPUT.json
 ```
 
 #### Use `INPUT` to seed our actor with categories


### PR DESCRIPTION
Hi! I came across this issue while going through the Getting Started guide.
`Apify.getInput()` returned null even though I had an `INPUT.json` file at the specified path. Turns out this is because this path is meant to be snake_case, not kebab-case.

```
INFO  System info {"apifyVersion":"0.20.4","apifyClientVersion":"0.6.0","osType":"Windows_NT","nodeVersion":"v12.12.0"}
```